### PR TITLE
EMI recipe viewer support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ base {
 repositories {
 
     maven {
-        name = 'Owo'
+        name = 'WispForest' // owo-lib
         url 'https://maven.wispforest.io'
     }
 
@@ -23,8 +23,13 @@ repositories {
     }
 
     maven {
-        name = 'REI'
-        url "https://maven.shedaniel.me/"
+        name = 'Shedaniel' // REI
+        url 'https://maven.shedaniel.me/'
+    }
+
+    maven {
+        name = 'TerraformersMC' // EMI
+        url 'https://maven.terraformersmc.com/'
     }
 }
 
@@ -41,13 +46,13 @@ dependencies {
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    // owo lib
+    // owo-lib
     // modImplementation "io.wispforest:owo-lib:${project.owo_version}"
     modImplementation "io.wispforest:lavender:${project.lavender_version}"
     include "io.wispforest:owo-sentinel:${project.owo_version}"
     annotationProcessor modImplementation("io.wispforest:owo-lib:${project.owo_version}")
 
-    // gecko lib
+    // GeckoLib
     modImplementation "software.bernie.geckolib:geckolib-fabric-${project.geckolib_version}"
 
     // Energy API
@@ -55,10 +60,19 @@ dependencies {
         transitive = false
     }
 
+    // EMI for Fabric
+    modCompileOnly "dev.emi:emi-fabric:${project.emi_version}:api"
+
     // REI for Fabric
-    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${rei_version}"
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api:${rei_version}"
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin:${rei_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api:${project.rei_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin:${project.rei_version}"
+
+    switch (project.recipe_viewer.toLowerCase(Locale.ROOT)) {
+        case "emi": modRuntimeOnly "dev.emi:emi-fabric:${project.emi_version}"; break
+        case "rei": modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"; break
+        case "disabled": break
+        default: println("Unknown recipe viewer specified: ${project.recipe_viewer}. Must be EMI, REI, or disabled.")
+    }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,10 @@ base {
     archivesName = project.archives_base_name
 }
 
+loom {
+    accessWidenerPath = file('src/main/resources/oritech.accesswidener')
+}
+
 repositories {
 
     maven {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 minecraft_version=1.20.4
 yarn_mappings=1.20.4+build.3
-loader_version=0.15.9
+loader_version=0.15.10
 
 # Mod Properties
 mod_version=1.0.0
@@ -20,4 +20,7 @@ owo_version=0.12.6+1.20.3
 lavender_version=0.1.7+1.20.3
 geckolib_version=1.20.4:4.4.4
 reborn_energy_version=3.0.0
-rei_version=14.0.688
+emi_version=1.1.6+1.20.4
+rei_version=14.1.727
+
+recipe_viewer=emi

--- a/src/main/java/rearth/oritech/init/compat/emi/LazyEmiRecipeCategory.java
+++ b/src/main/java/rearth/oritech/init/compat/emi/LazyEmiRecipeCategory.java
@@ -1,0 +1,17 @@
+package rearth.oritech.init.compat.emi;
+
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiRenderable;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+
+public class LazyEmiRecipeCategory extends EmiRecipeCategory {
+    public LazyEmiRecipeCategory(Identifier id, EmiRenderable icon) {
+        super(id, icon);
+    }
+
+    @Override
+    public Text getName() {
+        return Text.translatable("rei.process." + getId());
+    }
+}

--- a/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
+++ b/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
@@ -1,0 +1,89 @@
+package rearth.oritech.init.compat.emi;
+
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.recipe.RecipeManager;
+import net.minecraft.util.Identifier;
+import rearth.oritech.Oritech;
+import rearth.oritech.block.entity.machines.processing.AssemblerBlockEntity;
+import rearth.oritech.block.entity.machines.processing.AtomicForgeBlockEntity;
+import rearth.oritech.block.entity.machines.processing.CentrifugeBlockEntity;
+import rearth.oritech.block.entity.machines.processing.FoundryBlockEntity;
+import rearth.oritech.block.entity.machines.processing.FragmentForgeBlockEntity;
+import rearth.oritech.block.entity.machines.processing.PulverizerBlockEntity;
+import rearth.oritech.init.BlockContent;
+import rearth.oritech.init.compat.emi.recipes.OritechEmiRecipe;
+import rearth.oritech.init.recipes.RecipeContent;
+
+public class OritechEMIPlugin implements EmiPlugin {
+    // TODO: make this more similar to OritechREIPlugin
+
+    public static final EmiStack PULIVERIZER_WORKSTATION = EmiStack.of(BlockContent.PULVERIZER_BLOCK);
+    public static final EmiStack GRINDER_WORKSTATION = EmiStack.of(BlockContent.FRAGMENT_FORGE_BLOCK);
+    public static final EmiStack ASSEMBLER_WORKSTATION = EmiStack.of(BlockContent.ASSEMBLER_BLOCK );
+    public static final EmiStack FOUNDRY_WORKSTATION = EmiStack.of(BlockContent.FOUNDRY_BLOCK);
+    public static final EmiStack CENTRIFUGE_WORKSTATION = EmiStack.of(BlockContent.CENTRIFUGE_BLOCK);
+    public static final EmiStack ATOMIC_FORGE_WORKSTATION = EmiStack.of(BlockContent.ATOMIC_FORGE_BLOCK);
+
+    public static final EmiRecipeCategory PULVERIZER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "pulverizer"), PULIVERIZER_WORKSTATION);
+    public static final EmiRecipeCategory GRINDER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "grinder"), GRINDER_WORKSTATION);
+    public static final EmiRecipeCategory ASSEMBLER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "assembler"), ASSEMBLER_WORKSTATION);
+    public static final EmiRecipeCategory FOUNDRY_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "foundry"), FOUNDRY_WORKSTATION);
+    public static final EmiRecipeCategory CENTRIFUGE_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "centrifuge"), CENTRIFUGE_WORKSTATION);
+    public static final EmiRecipeCategory CENTRIFUGE_FLUID_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "centrifuge_fluid"), CENTRIFUGE_WORKSTATION);
+    public static final EmiRecipeCategory ATOMIC_FORGE_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "atomic_forge"), ATOMIC_FORGE_WORKSTATION);
+
+    @Override
+    public void register(EmiRegistry registry) {
+        // categories
+        registry.addCategory(PULVERIZER_CATEGORY);
+        registry.addCategory(GRINDER_CATEGORY);
+        registry.addCategory(ASSEMBLER_CATEGORY);
+        registry.addCategory(FOUNDRY_CATEGORY);
+        registry.addCategory(CENTRIFUGE_CATEGORY);
+        registry.addCategory(CENTRIFUGE_FLUID_CATEGORY);
+        registry.addCategory(ATOMIC_FORGE_CATEGORY);
+
+        // workstations
+        registry.addWorkstation(PULVERIZER_CATEGORY, PULIVERIZER_WORKSTATION);
+        registry.addWorkstation(GRINDER_CATEGORY, GRINDER_WORKSTATION);
+        registry.addWorkstation(ASSEMBLER_CATEGORY, ASSEMBLER_WORKSTATION);
+        registry.addWorkstation(FOUNDRY_CATEGORY, FOUNDRY_WORKSTATION);
+        registry.addWorkstation(CENTRIFUGE_CATEGORY, CENTRIFUGE_WORKSTATION);
+        registry.addWorkstation(CENTRIFUGE_FLUID_CATEGORY, CENTRIFUGE_WORKSTATION);
+        registry.addWorkstation(ATOMIC_FORGE_CATEGORY, ATOMIC_FORGE_WORKSTATION);
+
+        // recipes
+        RecipeManager manager = registry.getRecipeManager();
+        manager.listAllOfType(RecipeContent.PULVERIZER)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, PULVERIZER_CATEGORY, PulverizerBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.GRINDER)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, GRINDER_CATEGORY, FragmentForgeBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.ASSEMBLER)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, ASSEMBLER_CATEGORY, AssemblerBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.FOUNDRY)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, FOUNDRY_CATEGORY, FoundryBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.CENTRIFUGE)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, CENTRIFUGE_CATEGORY, CentrifugeBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.CENTRIFUGE_FLUID)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, CENTRIFUGE_FLUID_CATEGORY, CentrifugeBlockEntity.class))
+                .forEach(registry::addRecipe);
+        manager.listAllOfType(RecipeContent.ATOMIC_FORGE)
+                .stream()
+                .map(entry -> new OritechEmiRecipe(entry, ATOMIC_FORGE_CATEGORY, AtomicForgeBlockEntity.class))
+                .forEach(registry::addRecipe);
+    }
+}

--- a/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
+++ b/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
@@ -2,11 +2,11 @@ package rearth.oritech.init.compat.emi;
 
 import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
-import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.recipe.RecipeManager;
-import net.minecraft.util.Identifier;
-import rearth.oritech.Oritech;
+import rearth.oritech.block.base.entity.MachineBlockEntity;
 import rearth.oritech.block.entity.machines.processing.AssemblerBlockEntity;
 import rearth.oritech.block.entity.machines.processing.AtomicForgeBlockEntity;
 import rearth.oritech.block.entity.machines.processing.CentrifugeBlockEntity;
@@ -15,75 +15,32 @@ import rearth.oritech.block.entity.machines.processing.FragmentForgeBlockEntity;
 import rearth.oritech.block.entity.machines.processing.PulverizerBlockEntity;
 import rearth.oritech.init.BlockContent;
 import rearth.oritech.init.compat.emi.recipes.OritechEmiRecipe;
+import rearth.oritech.init.recipes.OritechRecipeType;
 import rearth.oritech.init.recipes.RecipeContent;
 
 public class OritechEMIPlugin implements EmiPlugin {
-    // TODO: make this more similar to OritechREIPlugin
-
-    public static final EmiStack PULIVERIZER_WORKSTATION = EmiStack.of(BlockContent.PULVERIZER_BLOCK);
-    public static final EmiStack GRINDER_WORKSTATION = EmiStack.of(BlockContent.FRAGMENT_FORGE_BLOCK);
-    public static final EmiStack ASSEMBLER_WORKSTATION = EmiStack.of(BlockContent.ASSEMBLER_BLOCK );
-    public static final EmiStack FOUNDRY_WORKSTATION = EmiStack.of(BlockContent.FOUNDRY_BLOCK);
-    public static final EmiStack CENTRIFUGE_WORKSTATION = EmiStack.of(BlockContent.CENTRIFUGE_BLOCK);
-    public static final EmiStack ATOMIC_FORGE_WORKSTATION = EmiStack.of(BlockContent.ATOMIC_FORGE_BLOCK);
-
-    public static final EmiRecipeCategory PULVERIZER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "pulverizer"), PULIVERIZER_WORKSTATION);
-    public static final EmiRecipeCategory GRINDER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "grinder"), GRINDER_WORKSTATION);
-    public static final EmiRecipeCategory ASSEMBLER_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "assembler"), ASSEMBLER_WORKSTATION);
-    public static final EmiRecipeCategory FOUNDRY_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "foundry"), FOUNDRY_WORKSTATION);
-    public static final EmiRecipeCategory CENTRIFUGE_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "centrifuge"), CENTRIFUGE_WORKSTATION);
-    public static final EmiRecipeCategory CENTRIFUGE_FLUID_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "centrifuge_fluid"), CENTRIFUGE_WORKSTATION);
-    public static final EmiRecipeCategory ATOMIC_FORGE_CATEGORY = new LazyEmiRecipeCategory(new Identifier(Oritech.MOD_ID, "atomic_forge"), ATOMIC_FORGE_WORKSTATION);
-
     @Override
     public void register(EmiRegistry registry) {
-        // categories
-        registry.addCategory(PULVERIZER_CATEGORY);
-        registry.addCategory(GRINDER_CATEGORY);
-        registry.addCategory(ASSEMBLER_CATEGORY);
-        registry.addCategory(FOUNDRY_CATEGORY);
-        registry.addCategory(CENTRIFUGE_CATEGORY);
-        registry.addCategory(CENTRIFUGE_FLUID_CATEGORY);
-        registry.addCategory(ATOMIC_FORGE_CATEGORY);
-
-        // workstations
-        registry.addWorkstation(PULVERIZER_CATEGORY, PULIVERIZER_WORKSTATION);
-        registry.addWorkstation(GRINDER_CATEGORY, GRINDER_WORKSTATION);
-        registry.addWorkstation(ASSEMBLER_CATEGORY, ASSEMBLER_WORKSTATION);
-        registry.addWorkstation(FOUNDRY_CATEGORY, FOUNDRY_WORKSTATION);
-        registry.addWorkstation(CENTRIFUGE_CATEGORY, CENTRIFUGE_WORKSTATION);
-        registry.addWorkstation(CENTRIFUGE_FLUID_CATEGORY, CENTRIFUGE_WORKSTATION);
-        registry.addWorkstation(ATOMIC_FORGE_CATEGORY, ATOMIC_FORGE_WORKSTATION);
-
-        // recipes
         RecipeManager manager = registry.getRecipeManager();
-        manager.listAllOfType(RecipeContent.PULVERIZER)
+        registerOritechCategory(registry, manager, RecipeContent.PULVERIZER, BlockContent.PULVERIZER_BLOCK, PulverizerBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.GRINDER, BlockContent.FRAGMENT_FORGE_BLOCK, FragmentForgeBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.ASSEMBLER, BlockContent.ASSEMBLER_BLOCK, AssemblerBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.FOUNDRY, BlockContent.FOUNDRY_BLOCK, FoundryBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.CENTRIFUGE, BlockContent.CENTRIFUGE_BLOCK, CentrifugeBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.CENTRIFUGE_FLUID, BlockContent.CENTRIFUGE_BLOCK, CentrifugeBlockEntity.class);
+        registerOritechCategory(registry, manager, RecipeContent.ATOMIC_FORGE, BlockContent.ATOMIC_FORGE_BLOCK, AtomicForgeBlockEntity.class);
+        
+        registry.addWorkstation(VanillaEmiRecipeCategories.SMELTING, EmiStack.of(BlockContent.POWERED_FURNACE_BLOCK));
+    }
+
+    private void registerOritechCategory(EmiRegistry registry, RecipeManager manager, OritechRecipeType recipeType, ItemConvertible machine,  Class<? extends MachineBlockEntity> screenProviderSource) {
+        var icon = EmiStack.of(machine);
+        var oriCategory = new LazyEmiRecipeCategory(recipeType.getIdentifier(), icon);
+        registry.addCategory(oriCategory);
+        registry.addWorkstation(oriCategory, icon);
+        manager.listAllOfType(recipeType)
                 .stream()
-                .map(entry -> new OritechEmiRecipe(entry, PULVERIZER_CATEGORY, PulverizerBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.GRINDER)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, GRINDER_CATEGORY, FragmentForgeBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.ASSEMBLER)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, ASSEMBLER_CATEGORY, AssemblerBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.FOUNDRY)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, FOUNDRY_CATEGORY, FoundryBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.CENTRIFUGE)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, CENTRIFUGE_CATEGORY, CentrifugeBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.CENTRIFUGE_FLUID)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, CENTRIFUGE_FLUID_CATEGORY, CentrifugeBlockEntity.class))
-                .forEach(registry::addRecipe);
-        manager.listAllOfType(RecipeContent.ATOMIC_FORGE)
-                .stream()
-                .map(entry -> new OritechEmiRecipe(entry, ATOMIC_FORGE_CATEGORY, AtomicForgeBlockEntity.class))
+                .map(entry -> new OritechEmiRecipe(entry, oriCategory, screenProviderSource))
                 .forEach(registry::addRecipe);
     }
 }

--- a/src/main/java/rearth/oritech/init/compat/emi/recipes/OritechEmiRecipe.java
+++ b/src/main/java/rearth/oritech/init/compat/emi/recipes/OritechEmiRecipe.java
@@ -6,10 +6,13 @@ import dev.emi.emi.api.render.EmiTexture;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import org.jetbrains.annotations.Nullable;
@@ -17,42 +20,57 @@ import rearth.oritech.block.base.entity.MachineBlockEntity;
 import rearth.oritech.init.recipes.OritechRecipe;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.List;
+
+import static rearth.oritech.client.ui.BasicMachineScreen.GUI_COMPONENTS;
 
 public class OritechEmiRecipe implements EmiRecipe {
     private final Identifier id;
-    private List<EmiIngredient> input;
-    private List<EmiStack> output;
-
+    private final List<EmiIngredient> itemInput;
+    private final List<EmiStack> itemOutput;
     private final EmiIngredient fluidInput;
     private final EmiStack fluidOutput;
+    private final List<EmiIngredient> totalInput;
+    private final List<EmiStack> totalOutput;
     private final int time;
 
     private final EmiRecipeCategory category;
-    
     private final MachineBlockEntity screenProvider;
 
     public OritechEmiRecipe(RecipeEntry<OritechRecipe> entry, EmiRecipeCategory category, Class<? extends MachineBlockEntity> screenProviderSource) {
-        this.id = entry.id();
-        this.input = entry.value().getInputs().stream().map(EmiIngredient::of).toList();
-        this.output = entry.value().getResults().stream().map(EmiStack::of).toList();
-
         if (entry.value().getFluidInput() != null) {
             this.fluidInput = EmiStack.of(entry.value().getFluidInput().variant().getFluid(), entry.value().getFluidInput().amount());
-            this.input.add(fluidInput);
         } else {
             this.fluidInput = null;
         }
         if (entry.value().getFluidOutput() != null) {
             this.fluidOutput = EmiStack.of(entry.value().getFluidOutput().variant().getFluid(), entry.value().getFluidOutput().amount());
-            this.output.add(this.fluidOutput);
         } else {
             this.fluidOutput = null;
         }
+
+        this.id = entry.id();
+
+        List<EmiIngredient> input = new ArrayList<>(entry.value().getInputs().stream().map(EmiIngredient::of).toList());
+        List<EmiStack> output = new ArrayList<>(entry.value().getResults().stream().map(EmiStack::of).toList());
+
+        this.itemInput = List.copyOf(input);
+        this.itemOutput = List.copyOf(output);
+
+        if (this.fluidInput != null) {
+            input.add(this.fluidInput);
+        }
+        if (this.fluidOutput != null) {
+            output.add(this.fluidOutput);
+        }
+
+        this.totalInput = List.copyOf(input);
+        this.totalOutput = List.copyOf(output);
+
         this.time = entry.value().getTime();
 
         this.category = category;
-
         try {
             this.screenProvider = screenProviderSource.getDeclaredConstructor(BlockPos.class, BlockState.class).newInstance(new BlockPos(0, 0, 0), Blocks.AIR.getDefaultState());
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
@@ -72,12 +90,12 @@ public class OritechEmiRecipe implements EmiRecipe {
 
     @Override
     public List<EmiIngredient> getInputs() {
-        return this.input;
+        return this.totalInput;
     }
 
     @Override
     public List<EmiStack> getOutputs() {
-        return this.output;
+        return this.totalOutput;
     }
 
     @Override
@@ -98,8 +116,8 @@ public class OritechEmiRecipe implements EmiRecipe {
         var offsetY = 17;
 
         // inputs
-        for (int i = 0; i < input.size(); i++) {
-            var entry = input.get(i);
+        for (int i = 0; i < this.itemInput.size(); i++) {
+            var entry = this.itemInput.get(i);
             var pos = slots.get(slotOffsets.inputStart() + i);
             widgets.addSlot(entry, pos.x() - offsetX, pos.y() - offsetY);
         }
@@ -108,8 +126,8 @@ public class OritechEmiRecipe implements EmiRecipe {
         widgets.addTexture(EmiTexture.EMPTY_ARROW, 80 - offsetX, 35 - offsetY);
 
         // outputs
-        for (int i = 0; i < output.size(); i++) {
-            var entry = output.get(i);
+        for (int i = 0; i < this.itemOutput.size(); i++) {
+            var entry = this.itemOutput.get(i);
             var pos = slots.get(slotOffsets.outputStart() + i);
             widgets.addSlot(entry, pos.x() - offsetX, pos.y() - offsetY).recipeContext(this);
         }
@@ -120,11 +138,19 @@ public class OritechEmiRecipe implements EmiRecipe {
 
         // fluids
         if (this.fluidInput != null) {
-            // ???
+            //root.child(rearth.oritech.client.ui.BasicMachineScreen.createFluidRenderer(fluid, 81000, new ScreenProvider.BarConfiguration(4, 5, 16, 50)));
+
+            var text = Text.literal(fluidInput.getAmount() * 1000 / FluidConstants.BUCKET + " mB " + fluidInput.getEmiStacks().get(0).getName().getString()).formatted(Formatting.DARK_AQUA);
+            widgets.addTexture(GUI_COMPONENTS, 3, 4, 18, 52, 48, 0, 14, 50, 98, 96)
+                    .tooltip(List.of(TooltipComponent.of(text.asOrderedText())));
         }
 
         if (this.fluidOutput != null) {
-            // ???
+            //root.child(rearth.oritech.client.ui.BasicMachineScreen.createFluidRenderer(fluid, 81000, new ScreenProvider.BarConfiguration(123, 5, 16, 50)));
+
+            var text = Text.literal(fluidOutput.getAmount() * 1000 / FluidConstants.BUCKET + " mB " + fluidOutput.getEmiStacks().get(0).getName().getString()).formatted(Formatting.DARK_AQUA);
+            widgets.addTexture(GUI_COMPONENTS, 122, 4, 18, 52, 48, 0, 14, 50, 98, 96)
+                    .tooltip(List.of(TooltipComponent.of(text.asOrderedText())));
         }
     }
 }

--- a/src/main/java/rearth/oritech/init/compat/emi/recipes/OritechEmiRecipe.java
+++ b/src/main/java/rearth/oritech/init/compat/emi/recipes/OritechEmiRecipe.java
@@ -1,0 +1,130 @@
+package rearth.oritech.init.compat.emi.recipes;
+
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.recipe.EmiRecipeCategory;
+import dev.emi.emi.api.render.EmiTexture;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.widget.WidgetHolder;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+import rearth.oritech.block.base.entity.MachineBlockEntity;
+import rearth.oritech.init.recipes.OritechRecipe;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class OritechEmiRecipe implements EmiRecipe {
+    private final Identifier id;
+    private List<EmiIngredient> input;
+    private List<EmiStack> output;
+
+    private final EmiIngredient fluidInput;
+    private final EmiStack fluidOutput;
+    private final int time;
+
+    private final EmiRecipeCategory category;
+    
+    private final MachineBlockEntity screenProvider;
+
+    public OritechEmiRecipe(RecipeEntry<OritechRecipe> entry, EmiRecipeCategory category, Class<? extends MachineBlockEntity> screenProviderSource) {
+        this.id = entry.id();
+        this.input = entry.value().getInputs().stream().map(EmiIngredient::of).toList();
+        this.output = entry.value().getResults().stream().map(EmiStack::of).toList();
+
+        if (entry.value().getFluidInput() != null) {
+            this.fluidInput = EmiStack.of(entry.value().getFluidInput().variant().getFluid(), entry.value().getFluidInput().amount());
+            this.input.add(fluidInput);
+        } else {
+            this.fluidInput = null;
+        }
+        if (entry.value().getFluidOutput() != null) {
+            this.fluidOutput = EmiStack.of(entry.value().getFluidOutput().variant().getFluid(), entry.value().getFluidOutput().amount());
+            this.output.add(this.fluidOutput);
+        } else {
+            this.fluidOutput = null;
+        }
+        this.time = entry.value().getTime();
+
+        this.category = category;
+
+        try {
+            this.screenProvider = screenProviderSource.getDeclaredConstructor(BlockPos.class, BlockState.class).newInstance(new BlockPos(0, 0, 0), Blocks.AIR.getDefaultState());
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public EmiRecipeCategory getCategory() {
+        return this.category;
+    }
+
+    @Override
+    public @Nullable Identifier getId() {
+        return this.id;
+    }
+
+    @Override
+    public List<EmiIngredient> getInputs() {
+        return this.input;
+    }
+
+    @Override
+    public List<EmiStack> getOutputs() {
+        return this.output;
+    }
+
+    @Override
+    public int getDisplayWidth() {
+        return 150;
+    }
+
+    @Override
+    public int getDisplayHeight() {
+        return 66;
+    }
+
+    @Override
+    public void addWidgets(WidgetHolder widgets) {
+        var slots = screenProvider.getGuiSlots();
+        var slotOffsets = screenProvider.getSlots();
+        var offsetX = 23;
+        var offsetY = 17;
+
+        // inputs
+        for (int i = 0; i < input.size(); i++) {
+            var entry = input.get(i);
+            var pos = slots.get(slotOffsets.inputStart() + i);
+            widgets.addSlot(entry, pos.x() - offsetX, pos.y() - offsetY);
+        }
+
+        // arrow
+        widgets.addTexture(EmiTexture.EMPTY_ARROW, 80 - offsetX, 35 - offsetY);
+
+        // outputs
+        for (int i = 0; i < output.size(); i++) {
+            var entry = output.get(i);
+            var pos = slots.get(slotOffsets.outputStart() + i);
+            widgets.addSlot(entry, pos.x() - offsetX, pos.y() - offsetY).recipeContext(this);
+        }
+
+        // data
+        var duration = String.format("%.0f", this.time / 20f);
+        widgets.addText(Text.of(duration + "s"), (int) (getDisplayWidth() * 0.3), (int) (getDisplayHeight() * 0.97), 0xFFFFFF, true);
+
+        // fluids
+        if (this.fluidInput != null) {
+            // ???
+        }
+
+        if (this.fluidOutput != null) {
+            // ???
+        }
+    }
+}

--- a/src/main/java/rearth/oritech/init/compat/rei/OritechDisplay.java
+++ b/src/main/java/rearth/oritech/init/compat/rei/OritechDisplay.java
@@ -1,4 +1,4 @@
-package rearth.oritech.init.compat;
+package rearth.oritech.init.compat.rei;
 
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;

--- a/src/main/java/rearth/oritech/init/compat/rei/OritechREIPlugin.java
+++ b/src/main/java/rearth/oritech/init/compat/rei/OritechREIPlugin.java
@@ -1,4 +1,4 @@
-package rearth.oritech.init.compat;
+package rearth.oritech.init.compat.rei;
 
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
@@ -8,7 +8,7 @@ import me.shedaniel.rei.api.common.util.EntryStacks;
 import net.minecraft.item.ItemConvertible;
 import rearth.oritech.block.entity.machines.processing.*;
 import rearth.oritech.init.BlockContent;
-import rearth.oritech.init.compat.Screens.OritechReiDisplay;
+import rearth.oritech.init.compat.rei.screens.OritechReiDisplay;
 import rearth.oritech.init.recipes.OritechRecipe;
 import rearth.oritech.init.recipes.OritechRecipeType;
 import rearth.oritech.init.recipes.RecipeContent;

--- a/src/main/java/rearth/oritech/init/compat/rei/screens/OritechReiDisplay.java
+++ b/src/main/java/rearth/oritech/init/compat/rei/screens/OritechReiDisplay.java
@@ -1,4 +1,4 @@
-package rearth.oritech.init.compat.Screens;
+package rearth.oritech.init.compat.rei.screens;
 
 import io.wispforest.owo.compat.rei.ReiUIAdapter;
 import io.wispforest.owo.ui.component.Components;
@@ -23,7 +23,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 import rearth.oritech.block.base.entity.MachineBlockEntity;
-import rearth.oritech.init.compat.OritechDisplay;
+import rearth.oritech.init.compat.rei.OritechDisplay;
 import rearth.oritech.init.recipes.OritechRecipeType;
 import rearth.oritech.util.ScreenProvider;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,8 +23,11 @@
 		"fabric-datagen": [
 			"rearth.oritech.OritechDataGenerator"
 		],
+		"emi": [
+			"rearth.oritech.init.compat.emi.OritechEMIPlugin"
+		],
 		"rei_client": [
-			"rearth.oritech.init.compat.OritechREIPlugin"
+          "rearth.oritech.init.compat.rei.OritechREIPlugin"
 		]
 	},
 	"mixins": [
@@ -39,6 +42,7 @@
 		"geckolib": "*"
 	},
 	"suggests": {
-		"another-mod": "*"
+		"emi": "*",
+		"rei": "*"
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,6 +32,7 @@
 	},
 	"mixins": [
 	],
+	"accessWidener": "oritech.accesswidener",
 	"depends": {
 		"fabricloader": ">=0.15.9",
 		"minecraft": "~1.20.4",

--- a/src/main/resources/oritech.accesswidener
+++ b/src/main/resources/oritech.accesswidener
@@ -1,0 +1,4 @@
+accessWidener v2 named
+
+accessible class net/minecraft/client/render/RenderLayer$MultiPhase
+accessible class net/minecraft/client/render/RenderLayer$MultiPhaseParameters


### PR DESCRIPTION
This PR adds support for [EMI](https://github.com/emilyploszaj/emi), a "featureful and accessible item and recipe viewer" (and an alternative to REI).

TODO:
- [ ] Arrow texture may render over slots in some cases?
- [ ] Duration text is misaligned
- [ ] Fluid inputs / outputs don't render
- [ ] Tags need translation keys
- [ ] ...?

The development environment can be switched between EMI and REI via the `recipe_viewer` variable in `gradle.properties`: set it to `emi` for EMI, or `rei` for REI.

Note that an unrelated access widener was added to the mod in order for it to build and run in a development environment (and in general).