### PR TITLE
Make machine output slots output-only

### DIFF
--- a/src/main/java/rearth/oritech/block/entity/machines/interaction/DestroyerBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/interaction/DestroyerBlockEntity.java
@@ -225,9 +225,9 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
     @Override
     public List<ScreenProvider.GuiSlot> getGuiSlots() {
         return List.of(
-          new GuiSlot(0, 117, 20),
-          new GuiSlot(1, 117, 38),
-          new GuiSlot(2, 117, 56));
+          new GuiSlot(0, 117, 20, true),
+          new GuiSlot(1, 117, 38, true),
+          new GuiSlot(2, 117, 56, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/interaction/LaserArmBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/interaction/LaserArmBlockEntity.java
@@ -661,9 +661,9 @@ public class LaserArmBlockEntity extends BlockEntity implements GeoBlockEntity, 
     @Override
     public List<GuiSlot> getGuiSlots() {
         return List.of(
-          new GuiSlot(0, 117, 20),
-          new GuiSlot(1, 117, 38),
-          new GuiSlot(2, 117, 56));
+          new GuiSlot(0, 117, 20, true),
+          new GuiSlot(1, 117, 38, true),
+          new GuiSlot(2, 117, 56, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/interaction/TreefellerBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/interaction/TreefellerBlockEntity.java
@@ -257,7 +257,7 @@ public class TreefellerBlockEntity extends BlockEntity implements BlockEntityTic
     public List<GuiSlot> getGuiSlots() {
         var list = new ArrayList<GuiSlot>();
         for (int i = 0; i < inventory.size(); i++) {
-            list.add(new GuiSlot(i, 40 + i * 19, 25));
+            list.add(new GuiSlot(i, 40 + i * 19, 25, true));
         }
         return list;
     }

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/AssemblerBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/AssemblerBlockEntity.java
@@ -50,7 +50,7 @@ public class AssemblerBlockEntity extends MultiblockMachineEntity {
           new GuiSlot(1, 56, 26),
           new GuiSlot(2, 38, 44),
           new GuiSlot(3, 56, 44),
-          new GuiSlot(4, 117, 36));
+          new GuiSlot(4, 117, 36, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/AtomicForgeBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/AtomicForgeBlockEntity.java
@@ -49,7 +49,7 @@ public class AtomicForgeBlockEntity extends MultiblockMachineEntity {
           new GuiSlot(0, 83, 21),
           new GuiSlot(1, 56, 38),
           new GuiSlot(2, 83, 54),
-          new GuiSlot(3, 117, 36));
+          new GuiSlot(3, 117, 36, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/CentrifugeBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/CentrifugeBlockEntity.java
@@ -253,8 +253,8 @@ public class CentrifugeBlockEntity extends MultiblockMachineEntity implements Fl
     public List<GuiSlot> getGuiSlots() {
         return List.of(
           new GuiSlot(0, 56, 38),
-          new GuiSlot(1, 113, 38),
-          new GuiSlot(2, 113, 56));
+          new GuiSlot(1, 113, 38, true),
+          new GuiSlot(2, 113, 56, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/FoundryBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/FoundryBlockEntity.java
@@ -45,7 +45,7 @@ public class FoundryBlockEntity extends MultiblockMachineEntity {
         return List.of(
           new GuiSlot(0, 56, 26),
           new GuiSlot(1, 56, 44),
-          new GuiSlot(2, 117, 36));
+          new GuiSlot(2, 117, 36, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/FragmentForgeBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/FragmentForgeBlockEntity.java
@@ -121,9 +121,9 @@ public class FragmentForgeBlockEntity extends MultiblockMachineEntity {
     public List<GuiSlot> getGuiSlots() {
         return List.of(
           new GuiSlot(0, 56, 38),
-          new GuiSlot(1, 117, 20),
-          new GuiSlot(2, 117, 38),
-          new GuiSlot(3, 117, 56));
+          new GuiSlot(1, 117, 20, true),
+          new GuiSlot(2, 117, 38, true),
+          new GuiSlot(3, 117, 56, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/PoweredFurnaceBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/PoweredFurnaceBlockEntity.java
@@ -146,7 +146,7 @@ public class PoweredFurnaceBlockEntity extends MultiblockMachineEntity {
     public List<GuiSlot> getGuiSlots() {
         return List.of(
           new GuiSlot(0, 56, 38),
-          new GuiSlot(1, 117, 38));
+          new GuiSlot(1, 117, 38, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/processing/PulverizerBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/processing/PulverizerBlockEntity.java
@@ -91,8 +91,8 @@ public class PulverizerBlockEntity extends UpgradableMachineBlockEntity {
     public List<GuiSlot> getGuiSlots() {
         return List.of(
           new GuiSlot(0, 56, 38),
-          new GuiSlot(1, 117, 38),
-          new GuiSlot(2, 135, 38));
+          new GuiSlot(1, 117, 38, true),
+          new GuiSlot(2, 135, 38, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
@@ -242,7 +242,7 @@ public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, 
     
     @Override
     public List<GuiSlot> getGuiSlots() {
-        return List.of(new GuiSlot(0, 50, 40), new GuiSlot(1, 100, 40));
+        return List.of(new GuiSlot(0, 50, 40), new GuiSlot(1, 100, 40, true));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/client/ui/BasicMachineOutputSlot.java
+++ b/src/main/java/rearth/oritech/client/ui/BasicMachineOutputSlot.java
@@ -1,0 +1,18 @@
+package rearth.oritech.client.ui;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+
+public class BasicMachineOutputSlot extends Slot {
+
+   // An output-only slot. This could be expanded to give XP to the player when items are removed, similar to the FurnaceOutputSlot.
+
+   public BasicMachineOutputSlot(Inventory inventory, int index, int x, int y) {
+      super(inventory, index, x, y);
+   }
+
+   public boolean canInsert(ItemStack stack) {
+      return false;
+   }
+}

--- a/src/main/java/rearth/oritech/client/ui/BasicMachineScreenHandler.java
+++ b/src/main/java/rearth/oritech/client/ui/BasicMachineScreenHandler.java
@@ -95,15 +95,19 @@ public class BasicMachineScreenHandler extends ScreenHandler {
     private void buildItemSlots() {
         
         for (var slot : screenData.getGuiSlots()) {
-            addMachineSlot(slot.index(), slot.x(), slot.y());
+            addMachineSlot(slot.index(), slot.x(), slot.y(), slot.output());
         }
         
         SlotGenerator.begin(this::addSlot, 8, 84)
           .playerInventory(playerInventory);
     }
     
-    public void addMachineSlot(int inventorySlot, int x, int y) {
-        this.addSlot(new Slot(inventory, inventorySlot, x, y));
+    public void addMachineSlot(int inventorySlot, int x, int y, boolean output) {
+        if (output) {
+            this.addSlot(new BasicMachineOutputSlot(inventory, inventorySlot, x, y));
+        } else {
+            this.addSlot(new Slot(inventory, inventorySlot, x, y));
+        }
     }
     
     @Override

--- a/src/main/java/rearth/oritech/util/ScreenProvider.java
+++ b/src/main/java/rearth/oritech/util/ScreenProvider.java
@@ -16,7 +16,11 @@ public interface ScreenProvider {
     
     default List<Pair<Text, Text>> getExtraExtensionLabels() {return List.of();}
     
-    record GuiSlot (int index, int x, int y) {}
+    record GuiSlot (int index, int x, int y, boolean output) {
+        public GuiSlot (int index, int x, int y) {
+            this(index, x, y, false);
+        }
+    }
 
     record BarConfiguration(int x, int y, int width, int height) {}
 


### PR DESCRIPTION
For #40 

Added an output parameter to the GuiSlot record, which makes the slot output only. Also went through and updated the machines to make them use output slots instead of regular slots.