### PR TITLE
#42 - reset progress when changing input items

### DIFF
--- a/src/main/java/rearth/oritech/block/base/entity/MachineBlockEntity.java
+++ b/src/main/java/rearth/oritech/block/base/entity/MachineBlockEntity.java
@@ -90,6 +90,9 @@ public abstract class MachineBlockEntity extends BlockEntity
             currentRecipe = OritechRecipe.DUMMY;     // reset recipe when invalid or no input is given
         
         if (recipeCandidate.isPresent() && canOutputRecipe(recipeCandidate.get().value()) && canProceed(recipeCandidate.get().value())) {
+
+            if (currentRecipe != recipeCandidate.get().value()) resetProgress();
+
             // this is separate so that progress is not reset when out of energy
             if (hasEnoughEnergy()) {
                 var activeRecipe = recipeCandidate.get().value();


### PR DESCRIPTION
Added a simple check to reset progress if the candidate recipe is not the current recipe.