### PR TITLE
#38 - only update door when powered state changes

### DIFF
--- a/src/main/java/rearth/oritech/block/blocks/decorative/TechDoorBlock.java
+++ b/src/main/java/rearth/oritech/block/blocks/decorative/TechDoorBlock.java
@@ -66,7 +66,10 @@ public class TechDoorBlock extends HorizontalFacingBlock implements BlockEntityP
         
         if (world.isClient) return;
         
+        var isOpen = state.get(OPENED);
         var isPowered = world.isReceivingRedstonePower(pos) || world.isReceivingRedstonePower(pos.up());
+        if (isOpen == isPowered) return;
+
         var aboveState = world.getBlockState(pos.up());
         
         if (!aboveState.getBlock().equals(BlockContent.TECH_DOOR_HINGE)) return;

--- a/src/main/java/rearth/oritech/init/BlockContent.java
+++ b/src/main/java/rearth/oritech/init/BlockContent.java
@@ -200,7 +200,7 @@ public class BlockContent implements BlockRegistryContainer {
     @ItemContent.ItemGroupTarget(ItemContent.Groups.decorative)
     public static final Block CEILING_LIGHT_HANGING = new WallMountedLight(FabricBlockSettings.copyOf(Blocks.GLOWSTONE).nonOpaque(), 12);
     @ItemContent.ItemGroupTarget(ItemContent.Groups.decorative)
-    public static final Block TECH_BUTTON = new TechRedstoneButton(BlockSetType.IRON, 50, FabricBlockSettings.copyOf(Blocks.STONE_BUTTON));
+    public static final Block TECH_BUTTON = new TechRedstoneButton(BlockSetType.IRON, 80, FabricBlockSettings.copyOf(Blocks.STONE_BUTTON));
     @ItemContent.ItemGroupTarget(ItemContent.Groups.decorative)
     public static final Block TECH_LEVER = new TechLever(FabricBlockSettings.copyOf(Blocks.STONE_BUTTON));
     @ItemContent.ItemGroupTarget(ItemContent.Groups.decorative)


### PR DESCRIPTION
The industrial door was making opening sounds any time there was a neighbor update.

This fixes it so that the sounds (and state changes) only happen when the powered status changes.

Also changed the industrial button tick duration from 50 to 80. That's a really long tick for a button, but it works a lot better with the industrial door animation.

As for note in #38 that regular buttons are too short for the industrial door, that seems like a choice. If you really want to use a regular button with the industrial door, you could make it work with more redstone.