### PR TITLE
Fixed duping issue with portable tank

### DIFF
--- a/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
@@ -29,6 +29,7 @@ import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
@@ -84,7 +85,7 @@ public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, 
     public void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.writeNbt(nbt, registryLookup);
         SingleVariantStorage.writeNbt(fluidStorage, FluidVariant.CODEC, nbt, registryLookup);
-        Inventories.writeNbt(nbt, inventory.heldStacks, false, registryLookup);
+        Inventories.writeNbt(nbt, DefaultedList.of(), false, registryLookup);
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/storage/SmallFluidTankEntity.java
@@ -85,7 +85,7 @@ public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, 
     public void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.writeNbt(nbt, registryLookup);
         SingleVariantStorage.writeNbt(fluidStorage, FluidVariant.CODEC, nbt, registryLookup);
-        Inventories.writeNbt(nbt, DefaultedList.of(), false, registryLookup);
+        Inventories.writeNbt(nbt, this.inventory.heldStacks, false, registryLookup);
     }
     
     @Override
@@ -93,6 +93,10 @@ public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, 
         super.readNbt(nbt, registryLookup);
         SingleVariantStorage.readNbt(fluidStorage, FluidVariant.CODEC, FluidVariant::blank, nbt, registryLookup);
         Inventories.readNbt(nbt, inventory.heldStacks, registryLookup);
+    }
+    
+    public void writeFluidToNbt(NbtCompound nbt) {
+        SingleVariantStorage.writeNbt(fluidStorage, FluidVariant.CODEC, nbt, world.getRegistryManager());
     }
     
     @Override


### PR DESCRIPTION
This PR address issue #55.

The `stack` variable had one issue since it kept containing the item that the block was holding inside his inventory but at the same time we were also dropping to the ground this same item, causing the duplication. 

I don't really know if the fix I've made is ideal, maybe you want to keep the functionnality of `writeNbt` the same but remove from the nbt data the item directly in the `onBreak` function?