### PR TITLE
Remember extract state when switching between regular pipe and connector

### DIFF
--- a/src/main/java/rearth/oritech/block/blocks/pipes/FluidPipeBlock.java
+++ b/src/main/java/rearth/oritech/block/blocks/pipes/FluidPipeBlock.java
@@ -4,9 +4,13 @@ import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidStorage;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import rearth.oritech.block.entity.pipes.GenericPipeInterfaceEntity;
 import rearth.oritech.init.BlockContent;
 
@@ -15,9 +19,17 @@ import java.util.HashMap;
 public class FluidPipeBlock extends GenericPipeBlock {
     
     public static HashMap<Identifier, GenericPipeInterfaceEntity.PipeNetworkData> FLUID_PIPE_DATA = new HashMap<>();
+    public static final BooleanProperty EXTRACT = FluidPipeConnectionBlock.EXTRACT;
     
     public FluidPipeBlock(Settings settings) {
         super(settings);
+        this.setDefaultState(this.getDefaultState().with(EXTRACT, false));
+    }
+
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        super.appendProperties(builder);
+        builder.add(EXTRACT);
     }
     
     @Override
@@ -38,6 +50,13 @@ public class FluidPipeBlock extends GenericPipeBlock {
     @Override
     public String getPipeTypeName() {
         return "fluid";
+    }
+
+    @Override
+    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
+        var baseState = super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);
+
+        return baseState.with(EXTRACT, state.get(EXTRACT));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/blocks/pipes/FluidPipeConnectionBlock.java
+++ b/src/main/java/rearth/oritech/block/blocks/pipes/FluidPipeConnectionBlock.java
@@ -9,11 +9,12 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.Oritech;
 import rearth.oritech.block.entity.pipes.FluidPipeInterfaceEntity;
@@ -58,6 +59,13 @@ public class FluidPipeConnectionBlock extends GenericPipeConnectionBlock {
     @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
         return new FluidPipeInterfaceEntity(pos, state);
+    }
+
+    @Override
+    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
+        var baseState = super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);
+
+        return baseState.with(EXTRACT, state.get(EXTRACT));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/blocks/pipes/ItemPipeBlock.java
+++ b/src/main/java/rearth/oritech/block/blocks/pipes/ItemPipeBlock.java
@@ -4,9 +4,13 @@ import net.fabricmc.fabric.api.lookup.v1.block.BlockApiLookup;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.state.StateManager;
+import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import rearth.oritech.block.entity.pipes.GenericPipeInterfaceEntity;
 import rearth.oritech.init.BlockContent;
 
@@ -15,9 +19,17 @@ import java.util.HashMap;
 public class ItemPipeBlock extends GenericPipeBlock {
     
     public static HashMap<Identifier, GenericPipeInterfaceEntity.PipeNetworkData> ITEM_PIPE_DATA = new HashMap<>();
+    public static final BooleanProperty EXTRACT = ItemPipeConnectionBlock.EXTRACT;
     
     public ItemPipeBlock(Settings settings) {
         super(settings);
+        this.setDefaultState(this.getDefaultState().with(EXTRACT, false));
+    }
+
+    @Override
+    protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
+        super.appendProperties(builder);
+        builder.add(EXTRACT);
     }
     
     @Override
@@ -38,6 +50,13 @@ public class ItemPipeBlock extends GenericPipeBlock {
     @Override
     public String getPipeTypeName() {
         return "item";
+    }
+
+    @Override
+    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
+        var baseState = super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);
+
+        return baseState.with(EXTRACT, state.get(EXTRACT));
     }
     
     @Override

--- a/src/main/java/rearth/oritech/block/blocks/pipes/ItemPipeConnectionBlock.java
+++ b/src/main/java/rearth/oritech/block/blocks/pipes/ItemPipeConnectionBlock.java
@@ -9,11 +9,12 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.Oritech;
 import rearth.oritech.block.entity.pipes.GenericPipeInterfaceEntity;
@@ -58,6 +59,13 @@ public class ItemPipeConnectionBlock extends GenericPipeConnectionBlock {
     @Override
     public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
         return new ItemPipeInterfaceEntity(pos, state);
+    }
+
+    @Override
+    public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
+        var baseState = super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);
+
+        return baseState.with(EXTRACT, state.get(EXTRACT));
     }
     
     @Override


### PR DESCRIPTION
Store "extract" state for Item and Fluid pipes when they are normal pipes.

This makes it so that a pipe that was a connector set to extract will still be set to extract any time it connects to another block.

For example, if a pipe is set to extract from a shulker box, then the shulker box is replaced by another shulker box, the pipe will still be set to extract from the new shulker box.