### PR TITLE
Make pipes connect to addons when addons are activated

### DIFF
--- a/src/main/java/rearth/oritech/block/base/block/MultiblockMachine.java
+++ b/src/main/java/rearth/oritech/block/base/block/MultiblockMachine.java
@@ -11,6 +11,7 @@ import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import rearth.oritech.network.NetworkContent;
+import rearth.oritech.util.MachineAddonController;
 import rearth.oritech.util.MultiblockMachineController;
 
 public abstract class MultiblockMachine extends UpgradableMachineBlock {
@@ -50,6 +51,8 @@ public abstract class MultiblockMachine extends UpgradableMachineBlock {
             // first time created
             if (isAssembled && !wasAssembled) {
                 NetworkContent.MACHINE_CHANNEL.serverHandle(entity).send(new NetworkContent.MachineSetupEventPacket(pos));
+                if (entity instanceof MachineAddonController controllerEntity)
+                    controllerEntity.initAddons();
                 return ActionResult.SUCCESS;
             }
             

--- a/src/main/java/rearth/oritech/util/MachineAddonController.java
+++ b/src/main/java/rearth/oritech/util/MachineAddonController.java
@@ -186,8 +186,10 @@ public interface MachineAddonController {
         for (var addon : addons) {
             var newState = addon.state()
                              .with(MachineAddonBlock.ADDON_USED, true);
-            world.setBlockState(addon.pos(), newState);
+            // Set controller before setting block state, otherwise the addon will think
+            // it's not connected to a machine the first time neighbor blocks are being updated.
             addon.addonEntity().setControllerPos(pos);
+            world.setBlockState(addon.pos(), newState);
         }
     }
     


### PR DESCRIPTION
Two small changes to addon initialization:

1) When settings an addon state to ADDON_USED, set the controller position before updating the block state.

When the block state changes, the neighbor pipes are updated. If the controller position isn't set first, then the pipes won't connect to the addon unless something else changes to make them update again.

This fixes the problem where pipes need to be broken and replaced to make them connect to an addon after it is activated.

2) When initializing a multiblock machine, also initialize the addons. This takes one step out of the initialization process.

If you're setting up a bunch of machines, you can add the machines, the machine cores, and the addons, then activate everything at once.

Or, if you have a machine with addons set up and you accidentally break a machine core you can replace the core and reactivate the machine.

This is a convenience, not a bugfix. You can already do this by right-clicking on the machine to initialize it, then right-clicking on the machine again to initialize the addons and show the menu.