### PR TITLE
Add silicon item tag for better compatibility with Energized Power

### DIFF
--- a/src/main/generated/data/c/tags/item/silicon.json
+++ b/src/main/generated/data/c/tags/item/silicon.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "oritech:silicon"
+  ]
+}

--- a/src/main/java/rearth/oritech/init/datagen/ItemTagGenerator.java
+++ b/src/main/java/rearth/oritech/init/datagen/ItemTagGenerator.java
@@ -87,6 +87,10 @@ public class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
           .add(BlockContent.IRON_PLATING_BLOCK.asItem())
           .add(BlockContent.NICKEL_PLATING_BLOCK.asItem());
         
+        // silicon
+        getOrCreateTagBuilder(TagContent.SILICON)
+          .add(ItemContent.SILICON);
+        
         // equipment enchanting
         getOrCreateTagBuilder(ItemTags.MINING_ENCHANTABLE)
           .add(ToolsContent.HAND_DRILL, ToolsContent.PROMETHIUM_PICKAXE);

--- a/src/main/java/rearth/oritech/init/datagen/data/TagContent.java
+++ b/src/main/java/rearth/oritech/init/datagen/data/TagContent.java
@@ -39,6 +39,9 @@ public class TagContent {
     
     // plating
     public static final TagKey<Item> MACHINE_PLATING = TagKey.of(RegistryKeys.ITEM, Oritech.id("plating"));
+
+    // silicon
+    public static final TagKey<Item> SILICON = TagKey.of(RegistryKeys.ITEM, Identifier.of("c", "silicon"));
     
     // blocks
     public static final TagKey<Block> DRILL_MINEABLE = TagKey.of(RegistryKeys.BLOCK, Oritech.id("mineable/drill"));


### PR DESCRIPTION
Energized Power is the other main tech pack available on 1.21 Fabric.

Adding c:silicon item tag so that Oritech silicon is interchangeable with EP silicon in recipes (EP already has silicon tagged as c:silicon).