### PR TITLE
Fixing inventory issues in portable tank and generator

### DIFF
--- a/src/main/java/rearth/oritech/block/entity/machines/generators/BasicGeneratorEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/generators/BasicGeneratorEntity.java
@@ -1,8 +1,11 @@
 package rearth.oritech.block.entity.machines.generators;
 
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
+import net.minecraft.item.BucketItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.Items;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
@@ -42,7 +45,11 @@ public class BasicGeneratorEntity extends UpgradableGeneratorBlockEntity {
         
         var fuelTime = FUEL_MAP.getOrDefault(firstItem.getItem(), 0);
         if (fuelTime > 0) {
-            firstItem.decrement(1);
+            if (firstItem.getItem() instanceof BucketItem) {
+                this.getInputView().set(0, ItemVariant.of(Items.BUCKET, firstItem.getComponentChanges()).toStack());
+            } else {
+                firstItem.decrement(1);
+            }
             progress = fuelTime;
             setCurrentMaxBurnTime(fuelTime);
             markNetDirty();

--- a/src/main/java/rearth/oritech/block/entity/machines/interaction/DronePortEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/interaction/DronePortEntity.java
@@ -167,7 +167,6 @@ public class DronePortEntity extends BlockEntity implements InventoryProvider, E
     protected void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.writeNbt(nbt, registryLookup);
         Inventories.writeNbt(nbt, inventory.heldStacks, false, registryLookup);
-        Inventories.writeNbt(nbt, cardInventory.heldStacks, false, registryLookup);
         addMultiblockToNbt(nbt);
         nbt.putLong("energy_stored", energyStorage.amount);
         
@@ -191,7 +190,6 @@ public class DronePortEntity extends BlockEntity implements InventoryProvider, E
     protected void readNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.readNbt(nbt, registryLookup);
         Inventories.readNbt(nbt, inventory.heldStacks, registryLookup);
-        Inventories.readNbt(nbt, cardInventory.heldStacks, registryLookup);
         loadMultiblockNbtData(nbt);
         
         energyStorage.amount = nbt.getLong("energy_stored");

--- a/src/main/java/rearth/oritech/block/entity/machines/interaction/DronePortEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/interaction/DronePortEntity.java
@@ -167,6 +167,7 @@ public class DronePortEntity extends BlockEntity implements InventoryProvider, E
     protected void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.writeNbt(nbt, registryLookup);
         Inventories.writeNbt(nbt, inventory.heldStacks, false, registryLookup);
+        Inventories.writeNbt(nbt, cardInventory.heldStacks, false, registryLookup);
         addMultiblockToNbt(nbt);
         nbt.putLong("energy_stored", energyStorage.amount);
         
@@ -190,6 +191,7 @@ public class DronePortEntity extends BlockEntity implements InventoryProvider, E
     protected void readNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.readNbt(nbt, registryLookup);
         Inventories.readNbt(nbt, inventory.heldStacks, registryLookup);
+        Inventories.readNbt(nbt, cardInventory.heldStacks, registryLookup);
         loadMultiblockNbtData(nbt);
         
         energyStorage.amount = nbt.getLong("energy_stored");

--- a/src/main/java/rearth/oritech/util/InventorySlotAssignment.java
+++ b/src/main/java/rearth/oritech/util/InventorySlotAssignment.java
@@ -5,7 +5,15 @@ public record InventorySlotAssignment(int inputStart, int inputCount, int output
         return input + inputStart;
     }
 
+    public boolean isInput(int slot) {
+        return slot >= inputStart && slot < inputStart + inputCount;
+    }
+
     public int outputToRealSlot(int output) {
         return output + outputStart;
+    }
+
+    public boolean isOutput(int slot) {
+        return slot >= outputStart && slot < outputStart + outputCount;
     }
 }

--- a/src/main/java/rearth/oritech/util/SimpleSidedInventory.java
+++ b/src/main/java/rearth/oritech/util/SimpleSidedInventory.java
@@ -1,0 +1,42 @@
+package rearth.oritech.util;
+
+import java.util.stream.IntStream;
+
+import net.minecraft.inventory.SidedInventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Direction;
+
+public class SimpleSidedInventory extends SimpleInventory implements SidedInventory {
+
+    private InventorySlotAssignment slotAssignment;
+
+    public SimpleSidedInventory(int size, InventorySlotAssignment slotAssignment) {
+        super(size);
+        this.slotAssignment = slotAssignment;
+    }
+
+    @Override
+    public boolean canExtract(int slot, ItemStack stack, Direction dir) {
+        return slotAssignment.isOutput(slot);
+    }
+
+    @Override
+    public boolean canInsert(int slot, ItemStack stack, Direction dir) {
+        return slotAssignment.isInput(slot);
+    }
+
+    @Override
+    public int[] getAvailableSlots(Direction side) {
+        switch (side) {
+            case Direction.UP:
+                return IntStream.range(slotAssignment.inputStart(), slotAssignment.inputStart() + slotAssignment.inputCount()).toArray();
+            case Direction.DOWN:
+                return IntStream.range(slotAssignment.outputStart(), slotAssignment.outputStart() + slotAssignment.outputCount()).toArray();
+            default:
+                return IntStream.concat(
+                    IntStream.range(slotAssignment.inputStart(), slotAssignment.inputStart() + slotAssignment.inputCount()),
+                    IntStream.range(slotAssignment.outputStart(), slotAssignment.outputStart() + slotAssignment.outputCount())).toArray();
+        }
+    }
+}


### PR DESCRIPTION
This fixes a few inventory issues
* Portable Tank was getting in a broken state when using item pipes to move buckets (Items.EMPTY vs Items.AIR comparison)
* Portable Tank was letting item pipes extract from the input slot
* Basic Generator was not leaving bucket behind when using lava bucket as fuel

As a minor benefit, the portable tank bucket processing and generator now save nbt data for the buckets when emptying/filling them.