### PR TITLE
Fixes #69, don't re-run onUseBlock for client

### DIFF
--- a/src/main/java/rearth/oritech/item/tools/LaserTargetDesignator.java
+++ b/src/main/java/rearth/oritech/item/tools/LaserTargetDesignator.java
@@ -24,7 +24,7 @@ public class LaserTargetDesignator extends Item {
     @Override
     public ActionResult useOnBlock(ItemUsageContext context) {
         if (context.getWorld().isClient()) {
-            return super.useOnBlock(context);
+            return ActionResult.SUCCESS;
         }
         
         var targetPos = context.getBlockPos();


### PR DESCRIPTION
Running super.onUseBlock on the client side was causing the offhand action to occur AND the main action to occur.

Now, offhand actions will only occur if none of the potential main hand actions are handled.