### PR TITLE
Adding compat recipes for Alloy Forgery

### DIFF
--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/adamant_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/adamant_alloy.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "alloy_forgery"
+      ]
+    }
+  ],
+  "type": "alloy_forgery:forging",
+  "inputs": [
+    {
+      "tag": "c:ingots/nickel"
+    },
+    {
+      "item": "minecraft:diamond"
+    }
+  ],
+  "output": {
+    "item": "oritech:adamant_ingot",
+    "count": 1
+  },
+  "min_forge_tier": 1,
+  "fuel_per_tick": 10
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/biosteel_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/biosteel_alloy.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "alloy_forgery"
+      ]
+    }
+  ],
+  "type": "alloy_forgery:forging",
+  "inputs": [
+    {
+      "tag": "c:ingots/iron"
+    },
+    {
+      "item": "oritech:raw_biopolymer"
+    }
+  ],
+  "output": {
+    "item": "oritech:biosteel_ingot",
+    "count": 1
+  },
+  "min_forge_tier": 1,
+  "fuel_per_tick": 10
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/copper_gem_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/copper_gem_alloy.json
@@ -1,0 +1,23 @@
+{
+    "fabric:load_conditions": [
+      {
+        "condition": "fabric:all_mods_loaded",
+        "values": [
+          "alloy_forgery"
+        ]
+      }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+      {
+        "item": "oritech:copper_gem",
+        "count": 2
+      }
+    ],
+    "output": {
+      "item": "minecraft:copper_ingot",
+      "count": 4
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 5
+  }

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/duratium_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/duratium_alloy.json
@@ -1,0 +1,25 @@
+{
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "alloy_forgery"
+            ]
+        }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+        {
+            "tag": "c:ingots/platinum"
+        },
+        {
+            "item": "minecraft:netherite_ingot"
+        }
+    ],
+    "output": {
+        "item": "oritech:duratium_ingot",
+        "count": 1
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 20
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/electrum_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/electrum_alloy.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "alloy_forgery"
+      ]
+    }
+  ],
+  "type": "alloy_forgery:forging",
+  "inputs": [
+    {
+      "tag": "c:ingots/gold"
+    },
+    {
+      "item": "minecraft:redstone"
+    }
+  ],
+  "output": {
+    "item": "oritech:electrum_ingot",
+    "count": 1
+  },
+  "min_forge_tier": 1,
+  "fuel_per_tick": 10
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/energite_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/energite_alloy.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "alloy_forgery"
+      ]
+    }
+  ],
+  "type": "alloy_forgery:forging",
+  "inputs": [
+    {
+      "tag": "c:ingots/nickel"
+    },
+    {
+      "item": "oritech:fluxite"
+    }
+  ],
+  "output": {
+    "item": "oritech:energite_ingot",
+    "count": 1
+  },
+  "min_forge_tier": 1,
+  "fuel_per_tick": 10
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/gold_gem_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/gold_gem_alloy.json
@@ -1,0 +1,23 @@
+{
+    "fabric:load_conditions": [
+      {
+        "condition": "fabric:all_mods_loaded",
+        "values": [
+          "alloy_forgery"
+        ]
+      }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+      {
+        "item": "oritech:gold_gem",
+        "count": 2
+      }
+    ],
+    "output": {
+      "item": "minecraft:gold_ingot",
+      "count": 4
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 10
+  }

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/iron_gem_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/iron_gem_alloy.json
@@ -1,0 +1,23 @@
+{
+    "fabric:load_conditions": [
+      {
+        "condition": "fabric:all_mods_loaded",
+        "values": [
+          "alloy_forgery"
+        ]
+      }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+      {
+        "item": "oritech:iron_gem",
+        "count": 2
+      }
+    ],
+    "output": {
+      "item": "minecraft:iron_ingot",
+      "count": 4
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 10
+  }

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/nickel_gem_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/nickel_gem_alloy.json
@@ -1,0 +1,23 @@
+{
+    "fabric:load_conditions": [
+      {
+        "condition": "fabric:all_mods_loaded",
+        "values": [
+          "alloy_forgery"
+        ]
+      }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+      {
+        "item": "oritech:nickel_gem",
+        "count": 2
+      }
+    ],
+    "output": {
+      "item": "oritech:nickel_ingot",
+      "count": 4
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 10
+  }

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/platinum_gem_alloy.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/platinum_gem_alloy.json
@@ -1,0 +1,23 @@
+{
+    "fabric:load_conditions": [
+        {
+            "condition": "fabric:all_mods_loaded",
+            "values": [
+                "alloy_forgery"
+            ]
+        }
+    ],
+    "type": "alloy_forgery:forging",
+    "inputs": [
+        {
+            "item": "oritech:platinum_gem",
+            "count": 2
+        }
+    ],
+    "output": {
+        "item": "oritech:platinum_ingot",
+        "count": 4
+    },
+    "min_forge_tier": 1,
+    "fuel_per_tick": 20
+}

--- a/src/main/resources/data/oritech/recipe/compat/alloy_forgery/steel_alloy_with_dust.json
+++ b/src/main/resources/data/oritech/recipe/compat/alloy_forgery/steel_alloy_with_dust.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "alloy_forgery"
+      ]
+    }
+  ],
+  "type": "alloy_forgery:forging",
+  "inputs": [
+    {
+      "tag": "c:ingots/iron"
+    },
+    {
+      "item": "oritech:coal_dust"
+    }
+  ],
+  "output": {
+    "item": "oritech:steel_ingot",
+    "count": 1
+  },
+  "min_forge_tier": 1,
+  "fuel_per_tick": 5
+}


### PR DESCRIPTION
Added some recipes so that Alloy Forgery can make Oritech alloys (including alloying the gems to multiply ingots).

The recipes have a load condition so that they'll only load if Alloy Forgery is installed.

I opted to add json recipes directly instead of setting up datagen for these, because I didn't want to pull in Alloy Forgery as a build dependency or fork the Alloy Forgery recipe / serializer for ~ 12 recipes.