### PR TITLE
New Jade plugin to show machine core controllers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,14 @@ repositories {
         url "https://modmaven.dev"
     }
 
+    maven { // for Jade
+        name = 'Curse'
+        url = 'https://www.cursemaven.com'
+        content {
+            includeGroup 'curse.maven'
+        }
+    }
+
     maven { // for EMI
         name = 'TerraformersMC'
         url 'https://maven.terraformersmc.com/'
@@ -91,6 +99,8 @@ dependencies {
 
     // athena (CTM)
     modRuntimeOnly "earth.terrarium.athena:athena-fabric-${athena_version}"
+
+    modImplementation "curse.maven:jade-324717:${jade_id}"
 
     // recipe viewer runtime
     switch (recipe_viewer.toLowerCase(Locale.ROOT)) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ reborn_energy_version=4.1.0
 rei_version=16.0.754
 athena_version=1.21:4.0.0
 emi_version=1.1.12+1.21
+jade_id=5639994
 
 # choose emi, rei or disabled, only applies to dev runs
 recipe_viewer=emi

--- a/src/main/java/rearth/oritech/block/entity/machines/MachineCoreEntity.java
+++ b/src/main/java/rearth/oritech/block/entity/machines/MachineCoreEntity.java
@@ -55,7 +55,7 @@ public class MachineCoreEntity extends BlockEntity implements InventoryProvider,
         this.markDirty();
     }
     
-    private MultiblockMachineController getCachedController() {
+    public MultiblockMachineController getCachedController() {
         if (!this.getCachedState().get(MachineCoreBlock.USED)) return null;
         
         if (controllerEntity == null)

--- a/src/main/java/rearth/oritech/init/compat/jade/OritechJadePlugin.java
+++ b/src/main/java/rearth/oritech/init/compat/jade/OritechJadePlugin.java
@@ -1,0 +1,24 @@
+package rearth.oritech.init.compat.jade;
+
+import rearth.oritech.Oritech;
+import rearth.oritech.block.blocks.MachineCoreBlock;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaCommonRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+
+@WailaPlugin
+public class OritechJadePlugin implements IWailaPlugin {
+
+    @Override
+    public void register(IWailaCommonRegistration registration) {
+        Oritech.LOGGER.info("Registering Jade providers");
+        registration.registerBlockDataProvider(OritechMachineCoreControllerProvider.INSTANCE, MachineCoreBlock.class);
+    }
+
+    @Override
+    public void registerClient(IWailaClientRegistration registration) {
+        Oritech.LOGGER.info("Registering Jade client providers");
+        registration.registerBlockComponent(OritechMachineCoreControllerProvider.INSTANCE, MachineCoreBlock.class);
+    }
+}

--- a/src/main/java/rearth/oritech/init/compat/jade/OritechMachineCoreControllerProvider.java
+++ b/src/main/java/rearth/oritech/init/compat/jade/OritechMachineCoreControllerProvider.java
@@ -1,0 +1,47 @@
+package rearth.oritech.init.compat.jade;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Identifier;
+import rearth.oritech.Oritech;
+import rearth.oritech.block.entity.machines.MachineCoreEntity;
+import rearth.oritech.util.MultiblockMachineController;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.IServerDataProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+public enum OritechMachineCoreControllerProvider implements IBlockComponentProvider, IServerDataProvider<BlockAccessor> {
+
+    INSTANCE;
+
+    private static final Identifier ID = Oritech.id("machine_core_controller");
+
+    @Override
+    public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+        if (accessor.getServerData().contains("controller")) {
+            tooltip.add(Text.translatable(accessor.getServerData().getString("controller")).formatted(Formatting.WHITE).formatted(Formatting.ITALIC));
+        }
+    }
+
+    @Override
+    public void appendServerData(NbtCompound data, BlockAccessor accessor) {
+        if (accessor.getBlockEntity() instanceof MachineCoreEntity coreEntity) {
+            var controllerEntity = coreEntity.getCachedController();
+            if (controllerEntity != null) {
+                var controller = accessor.getLevel().getBlockState(controllerEntity.getMachinePos()).getBlock();
+                data.putString("controller", controller.getTranslationKey());
+            }
+        }
+    }
+
+    @Override
+    public Identifier getUid() {
+        return ID;
+    }
+        
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,9 @@
 		],
 		"emi": [
 			"rearth.oritech.init.compat.emi.OritechEMIPlugin"
+		],
+		"jade": [
+			"rearth.oritech.init.compat.jade.OritechJadePlugin"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
Here's a very basic Jade plugin.

It should add the machine controller's name in italics underneath the machine core name when looking at a machine core.

It turns out that just registering a server data provider for the machine core ended up automatically adding the fluid, energy, and storage contents to the Jade panel as well due to the way the providers were already implemented on the machine cores.

So now Jade should give all of the same information for machines and connected machine cores, while still making it very obvious that it's a machine core.

![jade_machine](https://github.com/user-attachments/assets/2d05eb57-ee36-4607-8d65-93e437a5bf07)
![jade_core](https://github.com/user-attachments/assets/622a7175-691c-42e8-86fd-0b51d7ee6e47)