### PR TITLE
Fix NBT handling for dropped storage items

### DIFF
--- a/src/main/java/rearth/oritech/init/datagen/loot/NbtBlockLootFunction.java
+++ b/src/main/java/rearth/oritech/init/datagen/loot/NbtBlockLootFunction.java
@@ -53,7 +53,8 @@ public class NbtBlockLootFunction extends ConditionalLootFunction {
         // Removing it here so that the inventory items are not still stored in the dropped item's data
         if (nbt.contains("Items"))
             nbt.remove("Items");
-        stack.set(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(nbt));
+        if (!nbt.isEmpty())
+            stack.set(DataComponentTypes.CUSTOM_DATA, NbtComponent.of(nbt));
         return stack;
     }
 

--- a/src/main/java/rearth/oritech/item/other/SmallFluidTankBlockItem.java
+++ b/src/main/java/rearth/oritech/item/other/SmallFluidTankBlockItem.java
@@ -23,6 +23,7 @@ public class SmallFluidTankBlockItem extends BlockItem {
         
         if (!stack.contains(DataComponentTypes.CUSTOM_DATA)) return;
         var nbt = stack.get(DataComponentTypes.CUSTOM_DATA).copyNbt();
+        if (nbt.isEmpty()) return;
         var fluidStack = FluidStack.fromNbt(nbt);
         var variant = fluidStack.variant();
         var amount = fluidStack.amount() * 1000 / FluidConstants.BUCKET;


### PR DESCRIPTION
Avoid adding empty custom data to dropped items, and avoid null pointer crash if custom data is empty.