### PR TITLE
Fix #200 - Crash When Placing a Comparator Reading a Large Energy Storage

### DIFF
--- a/common/src/main/java/rearth/oritech/block/blocks/accelerator/AcceleratorSensorBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/accelerator/AcceleratorSensorBlock.java
@@ -15,6 +15,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.entity.accelerator.AcceleratorSensorBlockEntity;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class AcceleratorSensorBlock extends AcceleratorPassthroughBlock implemen
     
     @Override
     protected int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ((AcceleratorSensorBlockEntity) world.getBlockEntity(pos)).getComparatorOutput();
+        return ((ComparatorOutputProvider) world.getBlockEntity(pos)).getComparatorOutput();
     }
     
     @Nullable

--- a/common/src/main/java/rearth/oritech/block/blocks/addons/RedstoneAddonBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/addons/RedstoneAddonBlock.java
@@ -18,6 +18,7 @@ import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.entity.addons.RedstoneAddonBlockEntity;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 public class RedstoneAddonBlock extends MachineAddonBlock {
     
@@ -44,7 +45,7 @@ public class RedstoneAddonBlock extends MachineAddonBlock {
     
     @Override
     protected int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ((RedstoneAddonBlockEntity) world.getBlockEntity(pos)).currentOutput;
+        return ((ComparatorOutputProvider) world.getBlockEntity(pos)).getComparatorOutput();
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/arcane/EnchantmentCatalystBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/arcane/EnchantmentCatalystBlock.java
@@ -23,6 +23,7 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.entity.arcane.EnchantmentCatalystBlockEntity;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +42,7 @@ public class EnchantmentCatalystBlock extends HorizontalFacingBlock implements B
     
     @Override
     protected int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ((EnchantmentCatalystBlockEntity) world.getBlockEntity(pos)).getComparatorOutput();
+        return ((ComparatorOutputProvider) world.getBlockEntity(pos)).getComparatorOutput();
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/SmallFluidTank.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/SmallFluidTank.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.entity.storage.SmallFluidTankEntity;
 import rearth.oritech.init.BlockContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 import java.util.List;
 
@@ -65,7 +66,7 @@ public class SmallFluidTank extends Block implements BlockEntityProvider {
     
     @Override
     protected int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ((SmallFluidTankEntity) world.getBlockEntity(pos)).getComparatorOutput();
+        return ((ComparatorOutputProvider) world.getBlockEntity(pos)).getComparatorOutput();
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.base.entity.ExpandableEnergyStorageBlockEntity;
 import rearth.oritech.block.entity.storage.SmallStorageBlockEntity;
 import rearth.oritech.init.BlockContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 import rearth.oritech.util.MachineAddonController;
 
 import java.util.List;
@@ -79,7 +80,7 @@ public class SmallStorageBlock extends Block implements BlockEntityProvider {
     
     @Override
     protected int getComparatorOutput(BlockState state, World world, BlockPos pos) {
-        return ((SmallStorageBlockEntity) world.getBlockEntity(pos)).getComparatorOutput();
+        return ((ComparatorOutputProvider) world.getBlockEntity(pos)).getComparatorOutput();
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorSensorBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorSensorBlockEntity.java
@@ -6,8 +6,9 @@ import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import rearth.oritech.init.BlockEntitiesContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
-public class AcceleratorSensorBlockEntity extends BlockEntity implements BlockEntityTicker<AcceleratorSensorBlockEntity> {
+public class AcceleratorSensorBlockEntity extends BlockEntity implements BlockEntityTicker<AcceleratorSensorBlockEntity>, ComparatorOutputProvider {
     
     private float measuredSpeed;
     private long measuredTime;
@@ -42,7 +43,8 @@ public class AcceleratorSensorBlockEntity extends BlockEntity implements BlockEn
         this.measuredTime = world.getTime();
         dirty = true;
     }
-    
+
+    @Override
     public int getComparatorOutput() {
         if (measuredSpeed <= 0) {
             return 0;

--- a/common/src/main/java/rearth/oritech/block/entity/addons/RedstoneAddonBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/addons/RedstoneAddonBlockEntity.java
@@ -18,8 +18,9 @@ import rearth.oritech.client.init.ModScreens;
 import rearth.oritech.client.ui.RedstoneAddonScreenHandler;
 import rearth.oritech.init.BlockEntitiesContent;
 import rearth.oritech.network.NetworkContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
-public class RedstoneAddonBlockEntity extends AddonBlockEntity implements BlockEntityTicker<RedstoneAddonBlockEntity>, ExtendedScreenHandlerFactory {
+public class RedstoneAddonBlockEntity extends AddonBlockEntity implements BlockEntityTicker<RedstoneAddonBlockEntity>, ExtendedScreenHandlerFactory, ComparatorOutputProvider {
     
     private RedstoneControllable cachedController;
     public RedstoneMode activeMode = RedstoneMode.INPUT_CONTROL;
@@ -99,7 +100,12 @@ public class RedstoneAddonBlockEntity extends AddonBlockEntity implements BlockE
             cachedController.onRedstoneEvent(isPowered);
         
     }
-    
+
+    @Override
+    public int getComparatorOutput() {
+        return currentOutput;
+    }
+
     @Override
     public Object getScreenOpeningData(ServerPlayerEntity player) {
         sendDataToClient();
@@ -133,12 +139,21 @@ public class RedstoneAddonBlockEntity extends AddonBlockEntity implements BlockE
         OUTPUT_POWER, OUTPUT_SLOT, OUTPUT_PROGRESS, OUTPUT_ACTIVE, INPUT_CONTROL
     }
     
-    public interface RedstoneControllable {
+    public interface RedstoneControllable extends ComparatorOutputProvider {
         int getComparatorEnergyAmount();
         int getComparatorSlotAmount(int slot);
         int getComparatorProgress();
         int getComparatorActiveState();
         void onRedstoneEvent(boolean isPowered);
+
+        /**
+         * A redstone controllable machine only outputs a readable comparator signal from the controller addon block.
+         * @return 0
+         */
+        @Override
+        default int getComparatorOutput() {
+            return 0;
+        }
     }
     
 }

--- a/common/src/main/java/rearth/oritech/block/entity/arcane/EnchantmentCatalystBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/arcane/EnchantmentCatalystBlockEntity.java
@@ -44,7 +44,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 import java.util.List;
 
 public class EnchantmentCatalystBlockEntity extends BaseSoulCollectionEntity
-  implements InventoryProvider, EnergyApi.BlockProvider, ScreenProvider, GeoBlockEntity, BlockEntityTicker<EnchantmentCatalystBlockEntity>, ExtendedScreenHandlerFactory<ModScreens.BasicData> {
+  implements InventoryProvider, EnergyApi.BlockProvider, ScreenProvider, ComparatorOutputProvider, GeoBlockEntity, BlockEntityTicker<EnchantmentCatalystBlockEntity>, ExtendedScreenHandlerFactory<ModScreens.BasicData> {
     
     public static final RawAnimation IDLE = RawAnimation.begin().thenLoop("idle");
     public static final RawAnimation STABILIZED = RawAnimation.begin().thenLoop("stabilized");
@@ -275,7 +275,8 @@ public class EnchantmentCatalystBlockEntity extends BaseSoulCollectionEntity
     public boolean canAcceptSoul() {
         return collectedSouls < maxSouls;
     }
-    
+
+    @Override
     public int getComparatorOutput() {
         return calculateComparatorLevel();
     }

--- a/common/src/main/java/rearth/oritech/block/entity/arcane/SpawnerControllerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/arcane/SpawnerControllerBlockEntity.java
@@ -23,8 +23,9 @@ import rearth.oritech.client.init.ParticleContent;
 import rearth.oritech.init.BlockContent;
 import rearth.oritech.init.BlockEntitiesContent;
 import rearth.oritech.network.NetworkContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
-public class SpawnerControllerBlockEntity extends BaseSoulCollectionEntity implements BlockEntityTicker<SpawnerControllerBlockEntity> {
+public class SpawnerControllerBlockEntity extends BaseSoulCollectionEntity implements BlockEntityTicker<SpawnerControllerBlockEntity>, ComparatorOutputProvider {
     
     public int maxSouls = 100_000;
     public int collectedSouls = 0;
@@ -169,7 +170,8 @@ public class SpawnerControllerBlockEntity extends BaseSoulCollectionEntity imple
         }
         
     }
-    
+
+    @Override
     public int getComparatorOutput() {
         if (spawnedMob == null || maxSouls == 0) return 0;
         

--- a/common/src/main/java/rearth/oritech/block/entity/storage/CreativeStorageBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/storage/CreativeStorageBlockEntity.java
@@ -6,10 +6,11 @@ import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 import rearth.oritech.block.base.entity.ExpandableEnergyStorageBlockEntity;
 import rearth.oritech.init.BlockEntitiesContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 import java.util.List;
 
-public class CreativeStorageBlockEntity extends ExpandableEnergyStorageBlockEntity {
+public class CreativeStorageBlockEntity extends ExpandableEnergyStorageBlockEntity implements ComparatorOutputProvider {
 
     public CreativeStorageBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesContent.CREATIVE_STORAGE_ENTITY, pos, state);
@@ -35,6 +36,7 @@ public class CreativeStorageBlockEntity extends ExpandableEnergyStorageBlockEnti
         return Integer.MAX_VALUE;
     }
 
+    @Override
     public int getComparatorOutput() {
         if (energyStorage.amount == 0) return 0;
         return (int) (1 + ((energyStorage.amount / (float) energyStorage.capacity) * 14));

--- a/common/src/main/java/rearth/oritech/block/entity/storage/SmallFluidTankEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/storage/SmallFluidTankEntity.java
@@ -41,7 +41,7 @@ import rearth.oritech.util.*;
 
 import java.util.List;
 
-public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, InventoryProvider, ScreenProvider, ExtendedScreenHandlerFactory, BlockEntityTicker<SmallFluidTankEntity> {
+public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, InventoryProvider, ComparatorOutputProvider, ScreenProvider, ExtendedScreenHandlerFactory, BlockEntityTicker<SmallFluidTankEntity> {
     
     private boolean netDirty = false;
     private int lastComparatorOutput = 0;
@@ -219,7 +219,8 @@ public class SmallFluidTankEntity extends BlockEntity implements FluidProvider, 
         var slot = inventory.getStack(1);
         return (slot.isEmpty() || (slot.isStackable() && ItemStack.areItemsAndComponentsEqual(slot, bucket) && slot.getCount() < slot.getMaxCount()));
     }
-    
+
+    @Override
     public int getComparatorOutput() {
         if (fluidStorage.isResourceBlank()) return 0;
 

--- a/common/src/main/java/rearth/oritech/block/entity/storage/SmallStorageBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/storage/SmallStorageBlockEntity.java
@@ -6,10 +6,11 @@ import net.minecraft.util.math.Vec3i;
 import rearth.oritech.Oritech;
 import rearth.oritech.block.base.entity.ExpandableEnergyStorageBlockEntity;
 import rearth.oritech.init.BlockEntitiesContent;
+import rearth.oritech.util.ComparatorOutputProvider;
 
 import java.util.List;
 
-public class SmallStorageBlockEntity extends ExpandableEnergyStorageBlockEntity {
+public class SmallStorageBlockEntity extends ExpandableEnergyStorageBlockEntity implements ComparatorOutputProvider {
     
     public SmallStorageBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesContent.SMALL_STORAGE_ENTITY, pos, state);
@@ -38,6 +39,7 @@ public class SmallStorageBlockEntity extends ExpandableEnergyStorageBlockEntity 
         return Oritech.CONFIG.smallEnergyStorage.maxEnergyExtraction();
     }
 
+    @Override
     public int getComparatorOutput() {
         if (energyStorage.amount == 0) return 0;
         return (int) (1 + ((energyStorage.amount / (float) energyStorage.capacity) * 14));

--- a/common/src/main/java/rearth/oritech/util/ComparatorOutputProvider.java
+++ b/common/src/main/java/rearth/oritech/util/ComparatorOutputProvider.java
@@ -1,0 +1,6 @@
+package rearth.oritech.util;
+
+public interface ComparatorOutputProvider {
+
+	int getComparatorOutput();
+}


### PR DESCRIPTION
Fixes #200 

### Changes
- Added `ComparatorOutputProvider` to standardizing getting a comparator value from a block entity
- `RedstoneAddonBlockEntity.RedstoneControllable` overrides `ComparatorOutputProvider#getComparatorOutput` and always returns `0` since only the redstone addon should be used to read comparator output.

### Fix
Initial Cause: Invalid casting [in SmallStorageBlock](https://github.com/Rearth/Oritech/blob/c04d9bffc5c9f6732a78a07d969c7c458d4767ec/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java#L82)

We now cast to `ComparatorOutputProvider` since all block entities of a block with a comparator output should be its child. Since `RedstoneAddonBlockEntity.RedstoneControllable` overrides `ComparatorOutputProvider#getComparatorOutput` there is no longer an invalid cast.