### PR TITLE
Inventory Proxy Addon now being registered as a sided inventory. Fixes #304

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/addons/InventoryProxyAddonBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/addons/InventoryProxyAddonBlockEntity.java
@@ -1,6 +1,9 @@
 package rearth.oritech.block.entity.addons;
 
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -18,11 +21,12 @@ import rearth.oritech.block.blocks.addons.MachineAddonBlock;
 import rearth.oritech.client.ui.InventoryProxyScreenHandler;
 import rearth.oritech.init.BlockEntitiesContent;
 import rearth.oritech.util.ImplementedInventory;
+import rearth.oritech.util.InventoryProvider;
 import rearth.oritech.util.MachineAddonController;
 
 import java.util.Objects;
 
-public class InventoryProxyAddonBlockEntity extends AddonBlockEntity implements ImplementedInventory, ExtendedScreenHandlerFactory {
+public class InventoryProxyAddonBlockEntity extends AddonBlockEntity implements ImplementedInventory, InventoryProvider, ExtendedScreenHandlerFactory {
     
     private MachineAddonController cachedController;
     private int targetSlot = 0;
@@ -43,6 +47,11 @@ public class InventoryProxyAddonBlockEntity extends AddonBlockEntity implements 
         
         cachedController = (MachineAddonController) Objects.requireNonNull(world).getBlockEntity(getControllerPos());
         return cachedController;
+    }
+
+    @Override
+    public Storage<ItemVariant> getInventory(Direction direction) {
+        return InventoryStorage.of(this, direction);
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/init/BlockEntitiesContent.java
+++ b/common/src/main/java/rearth/oritech/init/BlockEntitiesContent.java
@@ -181,6 +181,7 @@ public class BlockEntitiesContent implements ArchitecturyRegistryContainer<Block
     @AssignSidedEnergy
     public static final BlockEntityType<ParticleCollectorBlockEntity> PARTICLE_COLLECTOR_BLOCK_ENTITY = FabricBlockEntityTypeBuilder.create(ParticleCollectorBlockEntity::new, BlockContent.PARTICLE_COLLECTOR_BLOCK).build();
     
+    @AssignSidedInventory
     public static final BlockEntityType<InventoryProxyAddonBlockEntity> INVENTORY_PROXY_ADDON_ENTITY = FabricBlockEntityTypeBuilder.create(InventoryProxyAddonBlockEntity::new, BlockContent.MACHINE_INVENTORY_PROXY_ADDON).build();
     
     @AssignSidedInventory


### PR DESCRIPTION
Very simple fix. This just makes the Inventory Proxy an InventoryProvider and registers it as a sided inventory (like all of the other machine blocks with inventories).