### PR TITLE
Machine frames will connect to any tag-configured frame support block.

### DIFF
--- a/common/src/main/generated/data/oritech/tags/block/frame_support.json
+++ b/common/src/main/generated/data/oritech/tags/block/frame_support.json
@@ -1,0 +1,6 @@
+{
+    "values": [
+      "oritech:metal_beam_block",
+      "oritech:machine_frame_block"
+    ]
+  }

--- a/common/src/main/java/rearth/oritech/block/blocks/decorative/MetalBeamBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/decorative/MetalBeamBlock.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.init.BlockContent;
+import rearth.oritech.init.TagContent;
 
 public class MetalBeamBlock extends Block {
     
@@ -58,8 +59,11 @@ public class MetalBeamBlock extends Block {
     }
     
     private BlockState getTargetState(WorldAccess world, BlockPos pos) {
-        var beamBelow = world.getBlockState(pos.down()).getBlock().equals(BlockContent.METAL_BEAM_BLOCK);
-        var beamAbove = world.getBlockState(pos.up()).getBlock().equals(BlockContent.METAL_BEAM_BLOCK);
+        var isFrameSupport = world.getBlockState(pos).isIn(TagContent.MACHINE_FRAME_SUPPORT);
+        var blockBelow = world.getBlockState(pos.down()).getBlock();
+        var beamBelow = blockBelow.equals(BlockContent.METAL_BEAM_BLOCK) || (isFrameSupport && blockBelow.equals(BlockContent.MACHINE_FRAME_BLOCK));
+        var blockAbove = world.getBlockState(pos.up()).getBlock();
+        var beamAbove = blockAbove.equals(BlockContent.METAL_BEAM_BLOCK) || (isFrameSupport && blockAbove.equals(BlockContent.MACHINE_FRAME_BLOCK));
         
         var state = getDefaultState();
         

--- a/common/src/main/java/rearth/oritech/block/blocks/interaction/MachineFrameBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/interaction/MachineFrameBlock.java
@@ -17,6 +17,7 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.Oritech;
+import rearth.oritech.init.TagContent;
 
 import java.util.List;
 import java.util.Objects;
@@ -29,18 +30,20 @@ public class MachineFrameBlock extends Block {
     public static final BooleanProperty EAST = ConnectingBlock.EAST;
     public static final BooleanProperty SOUTH = ConnectingBlock.SOUTH;      // south and west are only needed for voxel shapes
     public static final BooleanProperty WEST = ConnectingBlock.WEST;
+    public static final BooleanProperty UP = ConnectingBlock.UP;
+    public static final BooleanProperty DOWN = ConnectingBlock.DOWN;        // used to connect to pillars to make things look nice
     
     protected final VoxelShape[] boundingShapes;
     
     public MachineFrameBlock(Settings settings) {
         super(settings);
-        this.setDefaultState(getDefaultState().with(NORTH, false).with(EAST, false).with(SOUTH, false).with(WEST, false));
+        this.setDefaultState(getDefaultState().with(NORTH, false).with(EAST, false).with(SOUTH, false).with(WEST, false).with(UP, false).with(DOWN, false));
         boundingShapes = createShapes();
     }
     
     @Override
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
-        builder.add(NORTH, EAST, SOUTH, WEST);
+        builder.add(NORTH, EAST, SOUTH, WEST, UP, DOWN);
     }
     
     @Override
@@ -66,6 +69,10 @@ public class MachineFrameBlock extends Block {
             shape = VoxelShapes.union(shape, boundingShapes[3]);
         if (state.get(WEST))
             shape = VoxelShapes.union(shape, boundingShapes[4]);
+        if (state.get(UP))
+            shape = VoxelShapes.union(shape, boundingShapes[5]);
+        if (state.get(DOWN))
+            shape = VoxelShapes.union(shape, boundingShapes[6]);
         
         return shape;
     }
@@ -89,8 +96,10 @@ public class MachineFrameBlock extends Block {
         VoxelShape east = Block.createCuboidShape(0, 5, 5, 5, 11, 11);
         VoxelShape south = Block.createCuboidShape(5, 5, 11, 11, 11, 16);
         VoxelShape west = Block.createCuboidShape(11, 5, 5, 16, 11, 11);
+        VoxelShape up = Block.createCuboidShape(5, 5, 5, 11, 16, 11);
+        VoxelShape down = Block.createCuboidShape(5, 0, 5, 11, 5, 11);
         
-        return new VoxelShape[] {inner, north, west, south, east};
+        return new VoxelShape[] {inner, north, west, south, east, up, down};
     }
     
     @Nullable
@@ -102,8 +111,10 @@ public class MachineFrameBlock extends Block {
         var eastConnected = ctx.getWorld().getBlockState(ctx.getBlockPos().east()).getBlock() == this;
         var southConnected = ctx.getWorld().getBlockState(ctx.getBlockPos().south()).getBlock() == this;
         var westConnected = ctx.getWorld().getBlockState(ctx.getBlockPos().west()).getBlock() == this;
+        var upConnected = ctx.getWorld().getBlockState(ctx.getBlockPos().up()).isIn(TagContent.MACHINE_FRAME_SUPPORT);
+        var downConnected = ctx.getWorld().getBlockState(ctx.getBlockPos().down()).isIn(TagContent.MACHINE_FRAME_SUPPORT);
         
-        return Objects.requireNonNull(baseState).with(NORTH, northConnected).with(EAST, eastConnected).with(SOUTH, southConnected).with(WEST, westConnected);
+        return Objects.requireNonNull(baseState).with(NORTH, northConnected).with(EAST, eastConnected).with(SOUTH, southConnected).with(WEST, westConnected).with(UP, upConnected).with(DOWN, downConnected);
     }
     
     @Override
@@ -113,8 +124,10 @@ public class MachineFrameBlock extends Block {
         var eastConnected = world.getBlockState(pos.east()).getBlock() == this;
         var southConnected = world.getBlockState(pos.south()).getBlock() == this;
         var westConnected = world.getBlockState(pos.west()).getBlock() == this;
+        var upConnected = world.getBlockState(pos.up()).isIn(TagContent.MACHINE_FRAME_SUPPORT);
+        var downConnected = world.getBlockState(pos.down()).isIn(TagContent.MACHINE_FRAME_SUPPORT);
         
-        return state.with(NORTH, northConnected).with(EAST, eastConnected).with(SOUTH, southConnected).with(WEST, westConnected);
+        return state.with(NORTH, northConnected).with(EAST, eastConnected).with(SOUTH, southConnected).with(WEST, westConnected).with(UP, upConnected).with(DOWN, downConnected);
         
     }
 }

--- a/common/src/main/java/rearth/oritech/init/TagContent.java
+++ b/common/src/main/java/rearth/oritech/init/TagContent.java
@@ -54,6 +54,9 @@ public class TagContent {
     // plating
     public static final TagKey<Item> MACHINE_PLATING = TagKey.of(RegistryKeys.ITEM, Oritech.id("plating"));
 
+    // frame support
+    public static final TagKey<Block> MACHINE_FRAME_SUPPORT = TagKey.of(RegistryKeys.BLOCK, Oritech.id("frame_support"));
+
     // silicon
     public static final TagKey<Item> SILICON = TagKey.of(RegistryKeys.ITEM, Identifier.of("c", "silicon"));
 

--- a/common/src/main/resources/assets/oritech/blockstates/machine_frame_block.json
+++ b/common/src/main/resources/assets/oritech/blockstates/machine_frame_block.json
@@ -16,11 +16,47 @@
     },
     {
       "when": {
+        "south": "true"
+      },
+      "apply": {
+        "model": "oritech:block/machine_frame_outer",
+        "y": 0
+      }
+    },
+    {
+      "when": {
         "east": "true"
       },
       "apply": {
         "model": "oritech:block/machine_frame_outer",
         "y": 270
+      }
+    },
+    {
+      "when": {
+        "west": "true"
+      },
+      "apply": {
+        "model": "oritech:block/machine_frame_outer",
+        "y": 90
+      }
+    },
+    {
+      "when": {
+        "up": "true"
+      },
+      "apply": {
+        "model": "oritech:block/machine_frame_outer",
+        "x": 90
+      }
+    },
+    {
+      "when": {
+        "down": "true"
+      },
+      "apply": {
+        "model": "oritech:block/machine_frame_outer",
+        "x": -90
       }
     }
   ]

--- a/common/src/main/resources/assets/oritech/models/block/machine_frame_outer.json
+++ b/common/src/main/resources/assets/oritech/models/block/machine_frame_outer.json
@@ -9,14 +9,14 @@
 		{
 			"name": "frame_side",
 			"from": [5, 5, 11],
-			"to": [11, 11, 21],
+			"to": [11, 11, 16],
 			"faces": {
 				"north": {"uv": [0, 4, 4, 8], "texture": "#0"},
-				"east": {"uv": [0, 4, 4, 8], "texture": "#0"},
+				"east": {"uv": [2, 4, 4, 8], "texture": "#0"},
 				"south": {"uv": [8, 0, 12, 4], "texture": "#0"},
-				"west": {"uv": [0, 4, 4, 8], "texture": "#0"},
-				"up": {"uv": [8, 8, 4, 4], "texture": "#0"},
-				"down": {"uv": [8, 4, 4, 8], "texture": "#0"}
+				"west": {"uv": [0, 4, 2, 8], "texture": "#0"},
+				"up": {"uv": [8, 8, 4, 6], "texture": "#0"},
+				"down": {"uv": [8, 6, 4, 8], "texture": "#0"}
 			}
 		}
 	]

--- a/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/BlockTagGenerator.java
+++ b/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/BlockTagGenerator.java
@@ -134,5 +134,8 @@ public class BlockTagGenerator extends FabricTagProvider.BlockTagProvider {
         
         getOrCreateTagBuilder(TagContent.UNSTABLE_CONTAINER_SOURCES_HIGH)
           .add(BlockContent.BLACK_HOLE_BLOCK);
+
+        getOrCreateTagBuilder(TagContent.MACHINE_FRAME_SUPPORT)
+          .add(BlockContent.METAL_BEAM_BLOCK);
     }
 }


### PR DESCRIPTION
Fixes #207

The only block configured to be a frame support block is the metal beam. Metal beams blockstates were also changed to treat machine frames above/below them as beams as long as the beam is in the frame support tag.

Adding machine frames to the frame support tag will also make them connect to each other vertically.