### PR TITLE
Using FakePlayer class for machine PlayerEntity

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.RegistryKeys;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.text.Text;
@@ -33,6 +34,7 @@ import rearth.oritech.client.init.ParticleContent;
 import rearth.oritech.init.BlockContent;
 import rearth.oritech.init.BlockEntitiesContent;
 import rearth.oritech.network.NetworkContent;
+import rearth.oritech.util.FakeMachinePlayer;
 
 import java.util.List;
 import java.util.Objects;
@@ -47,7 +49,7 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
     // non-persistent
     public BlockPos quarryTarget = BlockPos.ORIGIN;
     public float targetHardness = 1f;
-    private PlayerEntity destroyerPlayerEntity = null;
+    private ServerPlayerEntity destroyerPlayerEntity = null;
     
     public DestroyerBlockEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesContent.DESTROYER_BLOCK_ENTITY, pos, state);
@@ -118,18 +120,8 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
     }
     
     private PlayerEntity getDestroyerPlayerEntity() {
-        if (destroyerPlayerEntity == null) {
-            destroyerPlayerEntity = new PlayerEntity(world, pos, 0, new GameProfile(UUID.randomUUID(), "laser")) {
-                @Override
-                public boolean isSpectator() {
-                    return false;
-                }
-                
-                @Override
-                public boolean isCreative() {
-                    return false;
-                }
-            };
+        if (destroyerPlayerEntity == null && world instanceof ServerWorld serverWorld) {
+            destroyerPlayerEntity = FakeMachinePlayer.create(serverWorld, new GameProfile(UUID.randomUUID(), "oritech_destroyer"));
         }
         
         return destroyerPlayerEntity;

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/LaserArmBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/LaserArmBlockEntity.java
@@ -248,29 +248,11 @@ public class LaserArmBlockEntity extends BlockEntity implements
     }
     
     public PlayerEntity getLaserPlayerEntity() {
+        if (!(world instanceof ServerWorld))
+            return null;
+
         if (laserPlayerEntity == null) {
-            laserPlayerEntity = new PlayerEntity(world, pos, 0, new GameProfile(UUID.randomUUID(), LASER_PLAYER_NAME)) {
-                @Override
-                public boolean isSpectator() {
-                    return false;
-                }
-                
-                @Override
-                public boolean isCreative() {
-                    return false;
-                }
-                
-                @Override
-                public boolean canTakeDamage() {
-                    return false;
-                }
-                
-                @Override
-                public boolean giveItemStack(ItemStack itemStack) {
-                    LaserArmBlockEntity.this.inventory.insert(itemStack, false);
-                    return true;
-                }
-            };
+            laserPlayerEntity = FakeMachinePlayer.create((ServerWorld)world, new GameProfile(UUID.randomUUID(), LASER_PLAYER_NAME), inventory);
         }
         
         if (hunterAddons > 0 && yieldAddons > 0) {

--- a/common/src/main/java/rearth/oritech/util/FakeMachinePlayer.java
+++ b/common/src/main/java/rearth/oritech/util/FakeMachinePlayer.java
@@ -1,0 +1,20 @@
+package rearth.oritech.util;
+
+import com.mojang.authlib.GameProfile;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import rearth.oritech.util.item.containers.SimpleInventoryStorage;
+
+public abstract class FakeMachinePlayer {
+    @ExpectPlatform
+    public static ServerPlayerEntity create(ServerWorld world, GameProfile profile) {
+        throw new AssertionError();
+    }
+
+    @ExpectPlatform
+    public static ServerPlayerEntity create(ServerWorld world, GameProfile profile, SimpleInventoryStorage inventory) {
+        throw new AssertionError();
+    }
+}

--- a/fabric/src/main/java/rearth/oritech/util/fabric/FakeMachinePlayerImpl.java
+++ b/fabric/src/main/java/rearth/oritech/util/fabric/FakeMachinePlayerImpl.java
@@ -1,0 +1,38 @@
+package rearth.oritech.util.fabric;
+
+import java.util.Map;
+
+import com.google.common.collect.MapMaker;
+import com.mojang.authlib.GameProfile;
+
+import net.fabricmc.fabric.api.entity.FakePlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import rearth.oritech.util.item.containers.SimpleInventoryStorage;
+
+// inspired by Fabric's FakePlayer and Neoforge's FakePlayerFactory
+
+// the only difference between this and the Neoforge Impl is the platform's version of FakePlayer that is being extended.
+public class FakeMachinePlayerImpl extends FakePlayer {
+    private static final Map<FakeMachinePlayerKey, FakePlayer> fakeMachinePlayers = new MapMaker().weakValues().makeMap();
+    private record FakeMachinePlayerKey (ServerWorld world, GameProfile profile) {}
+    
+    private final SimpleInventoryStorage inventory;
+
+    private FakeMachinePlayerImpl(ServerWorld world, GameProfile profile, SimpleInventoryStorage inventory) {
+        super(world, profile);
+        this.inventory = inventory;
+    }
+
+    public static ServerPlayerEntity create(ServerWorld world, GameProfile profile, SimpleInventoryStorage inventory) {
+        FakeMachinePlayerKey key = new FakeMachinePlayerKey(world, profile);
+        return fakeMachinePlayers.computeIfAbsent(key, k -> new FakeMachinePlayerImpl(k.world(), k.profile(), inventory));
+	}
+
+    @Override
+    public boolean giveItemStack(ItemStack itemStack) {
+        this.inventory.insert(itemStack, false);
+        return true;
+    }
+}

--- a/neoforge/src/main/java/rearth/oritech/util/neoforge/FakeMachinePlayerImpl.java
+++ b/neoforge/src/main/java/rearth/oritech/util/neoforge/FakeMachinePlayerImpl.java
@@ -1,0 +1,38 @@
+package rearth.oritech.util.neoforge;
+
+import java.util.Map;
+
+import com.google.common.collect.MapMaker;
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.neoforged.neoforge.common.util.FakePlayer;
+import rearth.oritech.util.item.containers.SimpleInventoryStorage;
+
+// inspired by Fabric's FakePlayer and Neoforge's FakePlayerFactory
+
+// the only difference between this and the Fabric Impl is the platform's version of FakePlayer that is being extended.
+public class FakeMachinePlayerImpl extends FakePlayer {
+    private static final Map<FakeMachinePlayerKey, FakePlayer> fakeMachinePlayers = new MapMaker().weakValues().makeMap();
+    private record FakeMachinePlayerKey (ServerWorld world, GameProfile profile) {}
+    
+    private final SimpleInventoryStorage inventory;
+
+    private FakeMachinePlayerImpl(ServerWorld world, GameProfile profile, SimpleInventoryStorage inventory) {
+        super(world, profile);
+        this.inventory = inventory;
+    }
+
+    public static ServerPlayerEntity create(ServerWorld world, GameProfile profile, SimpleInventoryStorage inventory) {
+        FakeMachinePlayerKey key = new FakeMachinePlayerKey(world, profile);
+        return fakeMachinePlayers.computeIfAbsent(key, k -> new FakeMachinePlayerImpl(k.world(), k.profile(), inventory));
+	}
+
+    @Override
+    public boolean giveItemStack(ItemStack itemStack) {
+        this.inventory.insert(itemStack, false);
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #321

Using FakePlayer classes that extend ServerPlayerEntity for machine PlayerEntity classes.

This also fixes the crash caused by Backpacked trying to cast the laser's PlayerEntity to a ServerPlayerEntity.

I did this with Architectury's @ExpectPlatform and Impl class detection. Let me know if you'd rather have it done the way you're doing the Item/Fluid/Energy API xplat classes.