### PR TITLE
Netherwart crop filter

### DIFF
--- a/common/src/main/java/rearth/oritech/block/behavior/LaserArmBlockBehavior.java
+++ b/common/src/main/java/rearth/oritech/block/behavior/LaserArmBlockBehavior.java
@@ -4,12 +4,14 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.CropBlock;
+import net.minecraft.block.NetherWartBlock;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import rearth.oritech.block.blocks.interaction.LaserArmBlock;
+import rearth.oritech.block.entity.interaction.DestroyerBlockEntity;
 import rearth.oritech.block.entity.interaction.LaserArmBlockEntity;
 import rearth.oritech.block.entity.storage.UnstableContainerBlockEntity;
 import rearth.oritech.client.init.ParticleContent;
@@ -27,7 +29,7 @@ public class LaserArmBlockBehavior {
      * Perform laser behavior on block
      */
     public boolean fireAtBlock(World world, LaserArmBlockEntity laserEntity, Block block, BlockPos blockPos, BlockState blockState, BlockEntity blockEntity) {
-        if (laserEntity.hasCropFilterAddon && block instanceof CropBlock crop && !crop.isMature(blockState))
+        if (laserEntity.hasCropFilterAddon && DestroyerBlockEntity.isImmatureCrop(blockState))
             return false;
         
         // has an energy storage, try to transfer power to it

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
@@ -4,6 +4,7 @@ import com.mojang.authlib.GameProfile;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.CocoaBlock;
 import net.minecraft.block.CropBlock;
 import net.minecraft.block.NetherWartBlock;
 import net.minecraft.block.entity.BlockEntity;
@@ -143,7 +144,8 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
     public static boolean isImmatureCrop(BlockState targetState) {
         Block targetBlock = targetState.getBlock();
         return (targetBlock instanceof CropBlock cropBlock && !cropBlock.isMature(targetState))
-            || (targetBlock instanceof NetherWartBlock && targetState.get(NetherWartBlock.AGE) < NetherWartBlock.MAX_AGE);
+            || (targetBlock instanceof NetherWartBlock && targetState.get(NetherWartBlock.AGE) < NetherWartBlock.MAX_AGE)
+            || (targetBlock instanceof CocoaBlock && targetState.get(CocoaBlock.AGE) < CocoaBlock.MAX_AGE);
     }
     
     private Pair<BlockPos, BlockState> getQuarryDownwardState(BlockPos toolPosition) {

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
@@ -5,6 +5,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.CropBlock;
+import net.minecraft.block.NetherWartBlock;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.UnbreakableComponent;
@@ -110,7 +111,7 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
         var targetState = Objects.requireNonNull(world).getBlockState(targetPosition);
         
         // skip not grown crops
-        if (hasCropFilterAddon && targetState.getBlock() instanceof CropBlock cropBlock && !cropBlock.isMature(targetState)) {
+        if (hasCropFilterAddon && isImmatureCrop(targetState)) {
             return false;
         }
         
@@ -137,6 +138,12 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
     
     private boolean hasQuarryTarget(BlockPos toolPosition) {
         return getQuarryDownwardState(toolPosition) != null;
+    }
+
+    public static boolean isImmatureCrop(BlockState targetState) {
+        Block targetBlock = targetState.getBlock();
+        return (targetBlock instanceof CropBlock cropBlock && !cropBlock.isMature(targetState))
+            || (targetBlock instanceof NetherWartBlock && targetState.get(NetherWartBlock.AGE) < NetherWartBlock.MAX_AGE);
     }
     
     private Pair<BlockPos, BlockState> getQuarryDownwardState(BlockPos toolPosition) {
@@ -182,7 +189,7 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
         if (targetHardness < 0) return;    // skip undestroyable blocks, such as bedrock
         
         // skip not grown crops
-        if (range == 1 && hasCropFilterAddon && targetState.getBlock() instanceof CropBlock cropBlock && !cropBlock.isMature(targetState)) {
+        if (range == 1 && hasCropFilterAddon && isImmatureCrop(targetState)) {
             return;
         }
         


### PR DESCRIPTION
The netherwart block and cocoa blocks aren't actually a crop block, but should still be treated by the crop filter as if they are.

This PR changes the immature crop test for the block destroyer and enderic laser when a crop filter addon is present so that immature netherwart or cocoa will not be destroyed.

Fixes #298 

(This is a duplicate of the accidentally closed #299, but opened from a feature branch instead of the main 1.21 branch)