### PR TITLE
Allow PlayerPortal to cross-dimensional teleportation

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/augmenter/PlayerAugments.java
+++ b/common/src/main/java/rearth/oritech/block/entity/augmenter/PlayerAugments.java
@@ -26,6 +26,9 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
+import net.minecraft.util.math.GlobalPos;
+import net.minecraft.world.World;
+
 import org.joml.Vector2i;
 import rearth.oritech.Oritech;
 import rearth.oritech.client.other.OreFinderRenderer;
@@ -529,7 +532,7 @@ public class PlayerAugments {
     @SuppressWarnings("UnstableApiUsage")
     public static class PlayerPortalAugment extends PlayerAugment {
         
-        private AttachmentType<BlockPos> OWN_TYPE;
+        private AttachmentType<GlobalPos> OWN_TYPE;
         
         protected PlayerPortalAugment(Identifier id, boolean toggleable) {
             super(id, toggleable, true);
@@ -537,15 +540,15 @@ public class PlayerAugments {
         
         @Override
         public void register() {
-            OWN_TYPE = AttachmentRegistry.<BlockPos>builder()
+            OWN_TYPE = AttachmentRegistry.<GlobalPos>builder()
                          .copyOnDeath()
-                         .persistent(BlockPos.CODEC)
-                         .initializer(() -> BlockPos.ORIGIN)
-                         // .syncWith(BlockPos.PACKET_CODEC.cast(), AttachmentSyncPredicate.targetOnly())   // todo either wait for FFAPI update or manually replace this
+                         .persistent(GlobalPos.CODEC)
+                         .initializer(() ->GlobalPos.create(World.OVERWORLD, BlockPos.ORIGIN))
+                         // .syncWith(GlobalPos.PACKET_CODEC.cast(), AttachmentSyncPredicate.targetOnly())   // todo either wait for FFAPI update or manually replace this
                          .buildAndRegister(this.id);
         }
         
-        public AttachmentType<BlockPos> getOwnType() {
+        public AttachmentType<GlobalPos> getOwnType() {
             return OWN_TYPE;
         }
         
@@ -556,7 +559,12 @@ public class PlayerAugments {
         
         @Override
         public void installToPlayer(PlayerEntity player) {
-            player.setAttached(OWN_TYPE, player.getBlockPos());
+            player.setAttached(OWN_TYPE, GlobalPos.create(
+                    player.getWorld().getRegistryKey(),
+                    player.getBlockPos()
+                )
+            );
+
             this.onInstalled(player);
             
             if (autoSync && !player.getWorld().isClient)
@@ -593,7 +601,7 @@ public class PlayerAugments {
                 portalEntity.setPosition(spawnPos);
                 portalEntity.setYaw(-player.getYaw() + 90);
                 world.spawnEntity(portalEntity);
-                portalEntity.target = targetPos.toCenterPos();
+                portalEntity.target = targetPos;
                 
                 world.playSound(null, BlockPos.ofFloored(spawnPos), SoundEvents.AMBIENT_CAVE.value(), SoundCategory.BLOCKS, 2, 1.2f);
                 

--- a/common/src/main/java/rearth/oritech/util/PortalEntity.java
+++ b/common/src/main/java/rearth/oritech/util/PortalEntity.java
@@ -1,12 +1,18 @@
 package rearth.oritech.util;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.Entity.RemovalReason;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.data.DataTracker;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.GlobalPos;
 import net.minecraft.world.World;
+import rearth.oritech.Oritech;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.animation.AnimatableManager;
@@ -20,7 +26,7 @@ public class PortalEntity extends Entity implements GeoEntity {
     
     private int age = 0;
     
-    public Vec3d target;
+    public GlobalPos target;
     protected static final RawAnimation PORTAL = RawAnimation.begin().thenPlay("create").thenLoop("idle");
     
     
@@ -36,8 +42,25 @@ public class PortalEntity extends Entity implements GeoEntity {
     
     @Override
     public void onPlayerCollision(PlayerEntity player) {
+        if (getWorld().isClient) return;
+
         if (target != null) {
-            player.teleport(target.x, target.y, target.z, true);
+            if (!(player instanceof ServerPlayerEntity serverPlayer)) return;
+            
+            ServerWorld targetWorld = this.getServer().getWorld(target.dimension());
+
+            if (targetWorld != null) {
+                BlockPos targetPos = target.pos();
+                Vec3d centerPos = targetPos.toCenterPos();
+
+                serverPlayer.teleport(
+                    targetWorld,
+                    centerPos.x, centerPos.y, centerPos.z,
+                    serverPlayer.getYaw(), serverPlayer.getPitch()
+                );
+            } else {
+                Oritech.LOGGER.warn("Attempted to teleport player to non-existent dimension: {}", target.dimension().getValue());
+            }
         }
         
         this.remove(RemovalReason.DISCARDED);


### PR DESCRIPTION
Fix player portal augmentation in non-overworld dimensions (Fixes #335)

This PR (based on #337) fixes portal augmentations to work properly across all dimensions. Previously, only the coordinates of the augmentation center were stored without dimension information, causing issues when traveling between dimensions.