### PR TITLE
Fix Addon tooltip

### DIFF
--- a/common/src/main/java/rearth/oritech/block/blocks/addons/MachineAddonBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/addons/MachineAddonBlock.java
@@ -236,13 +236,13 @@ public class MachineAddonBlock extends WallMountedBlock implements BlockEntityPr
         if (showExtra) {
             
             if (addonSettings.speedMultiplier() != 1) {
-                var displayedNumber = (int) ((1 - addonSettings.speedMultiplier()) * 100);
+                var displayedNumber = Math.round((1 - addonSettings.speedMultiplier()) * 100);
                 tooltip.add(Text.translatable("tooltip.oritech.addon_speed_desc").formatted(Formatting.DARK_GRAY)
                               .append(TooltipHelper.getFormattedValueChangeTooltip(displayedNumber)));
             }
             
             if (addonSettings.efficiencyMultiplier() != 1) {
-                var displayedNumber = (int) ((1 - addonSettings.efficiencyMultiplier()) * 100);
+                var displayedNumber = Math.round((1 - addonSettings.efficiencyMultiplier()) * 100);
                 tooltip.add(Text.translatable("tooltip.oritech.addon_efficiency_desc").formatted(Formatting.DARK_GRAY)
                               .append(TooltipHelper.getFormattedValueChangeTooltip(displayedNumber)));
             }


### PR DESCRIPTION
Due to floating-point precision issues, some addon display inaccurate values in tooptip.

![image](https://github.com/user-attachments/assets/cf5121c1-4470-4661-a7d4-06d969947439)
![image](https://github.com/user-attachments/assets/13a39869-f447-418c-8609-37757a1da71d)
https://github.com/Rearth/Oritech/blob/464265cea4c08b761bd772e9a7766e9f0eaafce6/common/src/main/java/rearth/oritech/init/BlockContent.java#L227
https://github.com/Rearth/Oritech/blob/464265cea4c08b761bd772e9a7766e9f0eaafce6/common/src/main/java/rearth/oritech/init/BlockContent.java#L232
