### PR TITLE
Adding biome modifiers to neoforge specific data files

### DIFF
--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/oil_spring.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/oil_spring.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:oil_spring",
+    "step": "lakes"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/oil_spring_desert.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/oil_spring_desert.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:village_desert_has_structure",
+    "features": "oritech:oil_spring_desert",
+    "step": "lakes"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/ore_platinum.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/ore_platinum.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:ore_platinum",
+    "step": "underground_ores"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/ore_platinum_end.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/ore_platinum_end.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_the_end",
+    "features": "oritech:ore_platinum_end",
+    "step": "underground_ores"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_common.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_common.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:resource_node_common",
+    "step": "top_layer_modification"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_other.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_other.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:ore_nickel",
+    "step": "underground_ores"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_rare.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/resource_node_rare.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:resource_node_rare",
+    "step": "top_layer_modification"
+  }

--- a/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/uranium_patch.json
+++ b/neoforge/src/main/resources/data/oritech/neoforge/biome_modifier/uranium_patch.json
@@ -1,0 +1,6 @@
+{
+    "type": "neoforge:add_features",
+    "biomes": "#minecraft:is_overworld",
+    "features": "oritech:uranium_patch",
+    "step": "underground_ores"
+  }


### PR DESCRIPTION
Oritech features were not being generated on Neoforge (see https://github.com/architectury/architectury-api/issues/480 for other people having the same issue).

I added some neoforge biome modifier json files (https://docs.neoforged.net/docs/worldgen/biomemodifier/) that should do the same thing. I haven't tested all of the features, but I did verify that I was able to create a new world and find ore boulders.