### PR TITLE
Add missing tags and remove hop from coal dusts

### DIFF
--- a/common/src/main/generated/data/c/tags/block/ores_in_ground/deepslate.json
+++ b/common/src/main/generated/data/c/tags/block/ores_in_ground/deepslate.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "oritech:deepslate_nickel_ore",
+    "oritech:deepslate_platinum_ore",
+    "oritech:deepslate_uranium_ore"
+  ]
+}

--- a/common/src/main/generated/data/c/tags/block/ores_in_ground/end_stone.json
+++ b/common/src/main/generated/data/c/tags/block/ores_in_ground/end_stone.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "oritech:endstone_platinum_ore"
+  ]
+}

--- a/common/src/main/generated/data/c/tags/block/ores_in_ground/stone.json
+++ b/common/src/main/generated/data/c/tags/block/ores_in_ground/stone.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "oritech:nickel_ore"
+  ]
+}

--- a/common/src/main/generated/data/c/tags/item/clumps/zinc.json
+++ b/common/src/main/generated/data/c/tags/item/clumps/zinc.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    {
+      "id": "create:crushed_raw_zinc",
+      "required": false
+    }
+  ]
+}

--- a/common/src/main/generated/data/c/tags/item/dusts/coal.json
+++ b/common/src/main/generated/data/c/tags/item/dusts/coal.json
@@ -1,9 +1,0 @@
-{
-  "values": [
-    "oritech:coal_dust",
-    {
-      "id": "immersiveengineering:dust_hop_graphite",
-      "required": false
-    }
-  ]
-}

--- a/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/BlockTagGenerator.java
+++ b/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/BlockTagGenerator.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
+import static rearth.oritech.init.TagContent.cBlockTag;
+
 public class BlockTagGenerator extends FabricTagProvider.BlockTagProvider {
     
     public BlockTagGenerator(FabricDataOutput output, CompletableFuture<RegistryWrapper.WrapperLookup> registriesFuture) {
@@ -65,6 +67,17 @@ public class BlockTagGenerator extends FabricTagProvider.BlockTagProvider {
           .add(BlockContent.DEEPSLATE_NICKEL_ORE)
           .add(BlockContent.DEEPSLATE_PLATINUM_ORE)
           .add(BlockContent.DEEPSLATE_URANIUM_ORE)
+          .add(BlockContent.ENDSTONE_PLATINUM_ORE);
+        
+        getOrCreateTagBuilder(cBlockTag("ores_in_ground/stone"))
+          .add(BlockContent.NICKEL_ORE);
+
+        getOrCreateTagBuilder(cBlockTag("ores_in_ground/deepslate"))
+          .add(BlockContent.DEEPSLATE_NICKEL_ORE)
+          .add(BlockContent.DEEPSLATE_PLATINUM_ORE)
+          .add(BlockContent.DEEPSLATE_URANIUM_ORE);
+        
+        getOrCreateTagBuilder(cBlockTag("ores_in_ground/end_stone"))
           .add(BlockContent.ENDSTONE_PLATINUM_ORE);
         
         getOrCreateTagBuilder(BlockTags.NEEDS_STONE_TOOL)

--- a/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/ItemTagGenerator.java
+++ b/fabricdatagen/src/main/java/rearth/oritech/fabricgen/datagen/ItemTagGenerator.java
@@ -51,6 +51,7 @@ public class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
         getOrCreateTagBuilder(getClumpTag("nickel")).add(ItemContent.NICKEL_CLUMP).addOptional(Identifier.of("create", "crushed_raw_nickel"));
         getOrCreateTagBuilder(getClumpTag("platinum")).add(ItemContent.PLATINUM_CLUMP).addOptional(Identifier.of("create", "crushed_raw_platinum"));
         // for compat
+        getOrCreateTagBuilder(getClumpTag("zinc")).addOptional(Identifier.of("create", "crushed_raw_zinc"));
         getOrCreateTagBuilder(getClumpTag("uranium")).addOptional(Identifier.of("create", "crushed_raw_uranium"));
         getOrCreateTagBuilder(getClumpTag("osmium")).addOptional(Identifier.of("create", "crushed_raw_osmium"));
         
@@ -117,7 +118,6 @@ public class ItemTagGenerator extends FabricTagProvider.ItemTagProvider {
         
         getOrCreateTagBuilder(TagContent.STEEL_INGOTS).add(ItemContent.STEEL_INGOT).add(ItemContent.BIOSTEEL_INGOT);
         getOrCreateTagBuilder(TagContent.QUARTZ_DUSTS).add(ItemContent.QUARTZ_DUST);
-        getOrCreateTagBuilder(TagContent.COAL_DUSTS).add(ItemContent.COAL_DUST).addOptional(Identifier.of("immersiveengineering", "dust_hop_graphite"));
         
         // vanilla variants
         getOrCreateTagBuilder(TagContent.COPPER_DUSTS).add(ItemContent.COPPER_DUST);

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/immersiveengineering/carbon_fibre_strands.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/immersiveengineering/carbon_fibre_strands.json
@@ -1,0 +1,25 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "immersiveengineering"
+    }
+  ],
+  "type": "oritech:centrifuge",
+  "fluidInputAmount": 0,
+  "fluidInputVariant": "minecraft:empty",
+  "fluidOutputAmount": 0,
+  "fluidOutputVariant": "minecraft:empty",
+  "ingredients": [
+    {
+      "item": "immersiveengineering:dust_hop_graphite"
+    }
+  ],
+  "results": [
+    {
+      "count": 1,
+      "id": "oritech:carbon_fibre_strands"
+    }
+  ],
+  "time": 200
+}

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/ImmersiveEngineeringRecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/ImmersiveEngineeringRecipeGenerator.java
@@ -26,6 +26,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
 import rearth.oritech.Oritech;
+import rearth.oritech.api.recipe.CentrifugeRecipeBuilder;
 import rearth.oritech.api.recipe.CentrifugeFluidRecipeBuilder;
 import rearth.oritech.api.recipe.FoundryRecipeBuilder;
 import rearth.oritech.api.recipe.FuelGeneratorRecipeBuilder;
@@ -77,6 +78,7 @@ public class ImmersiveEngineeringRecipeGenerator {
 
     private static void addCentrifuging(RecipeOutput exporter) {
         CentrifugeFluidRecipeBuilder.build().input(ItemTags.PLANKS).result(IEBlocks.WoodenDecoration.TREATED_WOOD.get(TreatedWoodStyles.HORIZONTAL).get().asItem()).fluidInput(IEFluids.CREOSOTE.still().get(), 0.125f).export(exporter, "compat/immersiveengineering/treated_planks");
+        CentrifugeRecipeBuilder.build().input(IEItems.Ingredients.DUST_HOP_GRAPHITE.get()).result(ItemContent.CARBON_FIBRE_STRANDS).export(exporter, "compat/immersiveengineering/carbon_fibre_strands");
     }
 
     private static void addGeneratorFuels(RecipeOutput exporter) {


### PR DESCRIPTION
* Added missing ore tags
* Added missing zinc clump tag
* Removed IE's dust_hop_graphite from c:dusts/coal
* Added new compat centrifuge recipe for hop graphite -> carbon fibre strands, which was the original intent of adding it to c:dusts/coal in the first place

Fixes #363