### PR TITLE
Fix nugget output, disable compat ore recipes when jaopca is loaded

### DIFF
--- a/common/src/main/java/rearth/oritech/api/recipe/util/MetalProcessingChainBuilder.java
+++ b/common/src/main/java/rearth/oritech/api/recipe/util/MetalProcessingChainBuilder.java
@@ -275,14 +275,14 @@ public class MetalProcessingChainBuilder {
         if (clumpItem != null) {
             CentrifugeRecipeBuilder.build()
                 .input(clumpIngredient)
-                .result(firstNonNull(centrifugeResult, gemItem))
+                .result(firstNonNull(centrifugeResult, gemItem), centrifugeResult != null ? centrifugeAmount : 1)
                 .result(Optional.fromNullable(dustByproduct), byproductAmount)
                 .timeMultiplier(timeMultiplier)
                 .export(exporter, resourcePath + "clump/" + metalName);
             CentrifugeFluidRecipeBuilder.build()
                 .input(clumpIngredient)
                 .fluidInput(Fluids.WATER)
-                .result(firstNonNull(centrifugeResult, gemItem), 2)
+                .result(firstNonNull(centrifugeResult, gemItem), centrifugeResult != null ? centrifugeAmount * 2 : 2)
                 .time(300).timeMultiplier(timeMultiplier)
                 .export(exporter, resourcePath + "clump/" + metalName);
         }

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/create/clump/zinc.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/create/clump/zinc.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "create"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge",
@@ -21,7 +28,7 @@
   ],
   "results": [
     {
-      "count": 1,
+      "count": 9,
       "id": "create:zinc_nugget"
     }
   ],

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge",

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge",

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/compat/mekanism/clump/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge",

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/create/clump/zinc.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/create/clump/zinc.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "create"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge_fluid",
@@ -21,7 +28,7 @@
   ],
   "results": [
     {
-      "count": 2,
+      "count": 18,
       "id": "create:zinc_nugget"
     }
   ],

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge_fluid",

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge_fluid",

--- a/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/centrifuge/fluid/compat/mekanism/clump/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:centrifuge_fluid",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/create/ore/zinc.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/create/ore/zinc.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "create"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/create/raw/zinc.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/create/raw/zinc.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "create"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerdust/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerdust/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerore/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerore/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerraw/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/energizedpowerraw/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/dust/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/ore/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/immersiveengineering/raw/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/dust/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/ore/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/grinder/compat/mekanism/raw/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:grinder",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/create/ore/zinc.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/create/ore/zinc.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "create"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerdust/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerdust/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerore/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerore/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerraw/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/energizedpowerraw/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "energizedpower"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/dust/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/ore/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/aluminum.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/aluminum.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/silver.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/immersiveengineering/raw/silver.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "immersiveengineering"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/dust/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/ore/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/lead.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/lead.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/osmium.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/osmium.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/tin.json
+++ b/neoforge/src/main/generated/data/oritech/recipe/pulverizer/compat/mekanism/raw/tin.json
@@ -3,6 +3,13 @@
     {
       "type": "neoforge:mod_loaded",
       "modid": "mekanism"
+    },
+    {
+      "type": "neoforge:not",
+      "value": {
+        "type": "neoforge:mod_loaded",
+        "modid": "jaopca"
+      }
     }
   ],
   "type": "oritech:pulverizer",

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/RecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/RecipeGenerator.java
@@ -24,7 +24,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.conditions.IConditionBuilder;
-import net.neoforged.neoforge.common.conditions.WithConditions;
 import owmii.powah.Powah;
 import rearth.oritech.api.recipe.CentrifugeRecipeBuilder;
 import rearth.oritech.api.recipe.CentrifugeFluidRecipeBuilder;
@@ -68,12 +67,12 @@ public class RecipeGenerator extends RecipeProvider implements IConditionBuilder
 
         ActuallyAdditionsRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(ActuallyAdditions.MODID)));
         AppliedEnergistics2RecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(AEConstants.MOD_ID)));
-        CreateRecipeGenerator.generateRecipes(packOutput, registries, exporter.withConditions(this.modLoaded(Create.ID)));
+        CreateRecipeGenerator.generateRecipes(this, packOutput, registries, exporter.withConditions(this.modLoaded(Create.ID)));
         EnderIORecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(EnderCore.MOD_ID)), this);
-        EnergizedPowerRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(EPAPI.MOD_ID)));
-        ImmersiveEngineeringRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(ImmersiveEngineering.MODID)));
+        EnergizedPowerRecipeGenerator.generateRecipes(this, exporter.withConditions(this.modLoaded(EPAPI.MOD_ID)));
+        ImmersiveEngineeringRecipeGenerator.generateRecipes(this, exporter.withConditions(this.modLoaded(ImmersiveEngineering.MODID)));
         IndustrialForegoingRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(Reference.MOD_ID)));
-        MekanismRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(Mekanism.MODID)));
+        MekanismRecipeGenerator.generateRecipes(this, exporter.withConditions(this.modLoaded(Mekanism.MODID)));
         MekanismGeneratorsRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(MekanismGenerators.MODID)));
         PneumaticcraftRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(Names.MOD_ID)));
         PowahRecipeGenerator.generateRecipes(exporter.withConditions(this.modLoaded(Powah.MOD_ID)));

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/CreateRecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/CreateRecipeGenerator.java
@@ -25,6 +25,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.conditions.IConditionBuilder;
 import rearth.oritech.Oritech;
 import rearth.oritech.api.recipe.CentrifugeFluidRecipeBuilder;
 import rearth.oritech.api.recipe.FoundryRecipeBuilder;
@@ -37,11 +38,11 @@ import rearth.oritech.init.TagContent;
 public class CreateRecipeGenerator {
     private static final String PATH = "compat/create/";
 
-    public static void generateRecipes(PackOutput packOutput, CompletableFuture<HolderLookup.Provider> registries, RecipeOutput exporter) { 
+    public static void generateRecipes(IConditionBuilder conditionBuilder, PackOutput packOutput, CompletableFuture<HolderLookup.Provider> registries, RecipeOutput exporter) { 
         addAlloying(exporter);
         addBlasting(exporter);
         addCentrifuging(exporter);
-        addMetalProcessing(exporter);
+        addMetalProcessing(conditionBuilder, exporter);
 
         CreateCrushingRecipeGen.registerAll(packOutput, registries, exporter);
         CreateMixingRecipeGen.registerAll(packOutput, registries, exporter);
@@ -68,7 +69,7 @@ public class CreateRecipeGenerator {
         CentrifugeFluidRecipeBuilder.build().input(AllItems.WHEAT_FLOUR.asItem()).result(AllItems.DOUGH.asItem()).fluidInput(Fluids.WATER).export(exporter, PATH + "dough");
     }
 
-    private static void addMetalProcessing(RecipeOutput exporter) {
+    private static void addMetalProcessing(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
         MetalProcessingChainBuilder.build("zinc").resourcePath(PATH)
             .ore(cItemTag("ores/zinc"))
             .rawOre(cItemTag("raw_materials/zinc"), AllItems.RAW_ZINC.asItem()).rawOreByproduct(Items.GUNPOWDER)
@@ -76,7 +77,7 @@ public class CreateRecipeGenerator {
             .nugget(cItemTag("nuggets/zinc"), AllItems.ZINC_NUGGET.asItem())
             .clump(cItemTag("clumps/zinc"), AllItems.CRUSHED_ZINC.asItem()).clumpByproduct(Items.GUNPOWDER).byproductAmount(1)
             .centrifugeResult(AllItems.ZINC_NUGGET.asItem(), 9)
-            .export(exporter);
+            .export(exporter.withConditions(conditionBuilder.not(conditionBuilder.modLoaded("jaopca"))));
     }
 
     private static class CreateCrushingRecipeGen extends CrushingRecipeGen {

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/EnergizedPowerRecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/EnergizedPowerRecipeGenerator.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.conditions.IConditionBuilder;
 import rearth.oritech.Oritech;
 import rearth.oritech.api.recipe.util.MetalProcessingChainBuilder;
 import rearth.oritech.init.BlockContent;
@@ -26,9 +27,9 @@ import rearth.oritech.init.TagContent;
 public class EnergizedPowerRecipeGenerator {
     public static final String PATH = "compat/energizedpower";
 
-    public static void generateRecipes(RecipeOutput exporter) {
+    public static void generateRecipes(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
         addOritechAlloys(exporter);
-        addEPMetalProcessingRecipes(exporter);
+        addEPMetalProcessingRecipes(conditionBuilder, exporter);
         addOritechAssemblerRecipes(exporter);
         // not adding EP assembling recipes to Oritech because EP uses multiple ingredients from each slot and Oritech only supports single ingredients
         addOritechOreFiltrationRecipes(exporter);
@@ -77,13 +78,13 @@ public class EnergizedPowerRecipeGenerator {
             new ItemStack(ItemContent.STEEL_INGOT), 500, "steel_with_dust");
     }
 
-    public static void addEPMetalProcessingRecipes(RecipeOutput exporter) {
+    public static void addEPMetalProcessingRecipes(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
         MetalProcessingChainBuilder.build("tin").resourcePath(PATH)
             .ore(CommonItemTags.ORES_TIN)
             .rawOre(CommonItemTags.RAW_MATERIALS_TIN, EPItems.RAW_TIN.get()).rawOreByproduct(Items.RAW_GOLD)
             .ingot(CommonItemTags.INGOTS_TIN, EPItems.TIN_INGOT.get())
             .dust(EPItems.TIN_DUST.get()).dustByproduct(ItemContent.COPPER_NUGGET)
-            .export(exporter);
+            .export(exporter.withConditions(conditionBuilder.not(conditionBuilder.modLoaded("jaopca"))));
     }
 
     public static void addOritechAssemblerRecipes(RecipeOutput exporter) {

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/ImmersiveEngineeringRecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/ImmersiveEngineeringRecipeGenerator.java
@@ -25,6 +25,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.conditions.IConditionBuilder;
 import rearth.oritech.Oritech;
 import rearth.oritech.api.recipe.CentrifugeRecipeBuilder;
 import rearth.oritech.api.recipe.CentrifugeFluidRecipeBuilder;
@@ -37,12 +38,12 @@ import rearth.oritech.init.TagContent;
 public class ImmersiveEngineeringRecipeGenerator {
     private static final String PATH = "compat/immersiveengineering/";
 
-    public static void generateRecipes(RecipeOutput exporter) {
+    public static void generateRecipes(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
         addAlloying(exporter);
         addIEAlloying(exporter);
         addCentrifuging(exporter);
         addGeneratorFuels(exporter);
-        addMetalProcessing(exporter);
+        addMetalProcessing(conditionBuilder, exporter);
     }
 
     private static void addAlloying(RecipeOutput exporter) {
@@ -86,7 +87,8 @@ public class ImmersiveEngineeringRecipeGenerator {
         FuelGeneratorRecipeBuilder.build().fluidInput(IEFluids.HIGH_POWER_BIODIESEL.still().get(), 0.1f).timeInSeconds(12).export(exporter, PATH + "highpowerbiodiesel");
     }
 
-    private static void addMetalProcessing(RecipeOutput exporter) {
+    private static void addMetalProcessing(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
+        var conditionExporter = exporter.withConditions(conditionBuilder.not(conditionBuilder.modLoaded("jaopca")));
         // bauxite/aluminum
         MetalProcessingChainBuilder.build("aluminum").resourcePath(PATH)
             .ore(cItemTag("ores/aluminum"))
@@ -94,7 +96,7 @@ public class ImmersiveEngineeringRecipeGenerator {
             .ingot(IETags.getTagsFor(EnumMetals.ALUMINUM).ingot, IEItems.Metals.INGOTS.get(EnumMetals.ALUMINUM).get())
             .nugget(IETags.getTagsFor(EnumMetals.ALUMINUM).nugget, IEItems.Metals.NUGGETS.get(EnumMetals.ALUMINUM).get())
             .dust(IEItems.Metals.DUSTS.get(EnumMetals.ALUMINUM).get()).dustByproduct(ItemContent.QUARTZ_DUST).byproductAmount(1)
-            .export(exporter);
+            .export(conditionExporter);
         // silver
         MetalProcessingChainBuilder.build("silver").resourcePath(PATH)
             .ore(cItemTag("ores/silver"))
@@ -102,7 +104,7 @@ public class ImmersiveEngineeringRecipeGenerator {
             .ingot(IETags.getTagsFor(EnumMetals.SILVER).ingot, IEItems.Metals.INGOTS.get(EnumMetals.SILVER).get())
             .nugget(IETags.getTagsFor(EnumMetals.SILVER).nugget, IEItems.Metals.NUGGETS.get(EnumMetals.SILVER).get())
             .dust(IEItems.Metals.DUSTS.get(EnumMetals.SILVER).get()).dustByproduct(ItemContent.SMALL_COPPER_DUST)
-            .export(exporter);
+            .export(conditionExporter);
         // lead
         MetalProcessingChainBuilder.build("lead").resourcePath(PATH)
             .ore(cItemTag("ores/lead"))
@@ -110,6 +112,6 @@ public class ImmersiveEngineeringRecipeGenerator {
             .ingot(IETags.getTagsFor(EnumMetals.LEAD).ingot, IEItems.Metals.INGOTS.get(EnumMetals.LEAD).get())
             .nugget(IETags.getTagsFor(EnumMetals.LEAD).nugget, IEItems.Metals.NUGGETS.get(EnumMetals.LEAD).get())
             .dust(IEItems.Metals.DUSTS.get(EnumMetals.LEAD).get()).dustByproduct(ItemContent.SMALL_GOLD_DUST)
-            .export(exporter);
+            .export(conditionExporter);
     }
 }

--- a/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/MekanismRecipeGenerator.java
+++ b/neoforgedatagen/src/main/java/rearth/oritech/neoforgegen/datagen/compat/MekanismRecipeGenerator.java
@@ -18,6 +18,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.conditions.IConditionBuilder;
 import rearth.oritech.Oritech;
 import rearth.oritech.api.recipe.AtomicForgeRecipeBuilder;
 import rearth.oritech.api.recipe.FoundryRecipeBuilder;
@@ -29,11 +30,11 @@ import rearth.oritech.init.TagContent;
 public class MekanismRecipeGenerator {
     private static final String PATH = "compat/mekanism/";
 
-    public static void generateRecipes(RecipeOutput exporter) {
+    public static void generateRecipes(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
         addAlloying(exporter);
         addAtomicForging(exporter);
         addDustGrinding(exporter);
-        addMetalProcessing(exporter);
+        addMetalProcessing(conditionBuilder, exporter);
         addMekInfusing(exporter);
     }
 
@@ -101,7 +102,8 @@ public class MekanismRecipeGenerator {
         RecipeHelpers.addDustRecipe(exporter, of(Tags.Items.OBSIDIANS), MekanismItems.OBSIDIAN_DUST.asItem(), "compat/mekanism/dust/obsidian");
     }
     
-    private static void addMetalProcessing(RecipeOutput exporter) {
+    private static void addMetalProcessing(IConditionBuilder conditionBuilder, RecipeOutput exporter) {
+        var conditionExporter = exporter.withConditions(conditionBuilder.not(conditionBuilder.modLoaded("jaopca")));
         // osmium
         MetalProcessingChainBuilder.build("osmium").resourcePath(PATH)
             .ore(MekanismTags.Items.ORES.get(OreType.OSMIUM))
@@ -119,7 +121,7 @@ public class MekanismRecipeGenerator {
             .dustByproduct(ItemContent.SMALL_PLATINUM_DUST)
             .byproductAmount(2)
             .timeMultiplier(1.5f)
-            .export(exporter);
+            .export(conditionExporter);
         // tin
         MetalProcessingChainBuilder.build("tin").resourcePath(PATH)
             .ore(MekanismTags.Items.ORES.get(OreType.TIN))
@@ -135,7 +137,7 @@ public class MekanismRecipeGenerator {
             .centrifugeResult(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.DUST, PrimaryResource.TIN).asItem())
             .dust(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.DUST, PrimaryResource.TIN).asItem())
             .dustByproduct(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.NUGGET, PrimaryResource.LEAD).asItem())
-            .export(exporter);
+            .export(conditionExporter);
         // lead
         MetalProcessingChainBuilder.build("lead").resourcePath(PATH)
             .ore(MekanismTags.Items.ORES.get(OreType.LEAD))
@@ -151,7 +153,7 @@ public class MekanismRecipeGenerator {
             .centrifugeResult(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.DUST, PrimaryResource.LEAD).asItem())
             .dust(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.DUST, PrimaryResource.LEAD).asItem())
             .dustByproduct(MekanismItems.PROCESSED_RESOURCES.get(ResourceType.NUGGET, PrimaryResource.TIN).asItem())
-            .export(exporter);
+            .export(conditionExporter);
     }
 
     private static void addMekInfusing(RecipeOutput exporter) {


### PR DESCRIPTION
* Fixed nugget output for centrifuge recipes (it respects centrifugeAmount now)
* Added a not(modLoaded("jaopca")) condition to NeoForge compat ore processing recipes

Fixes #381