### PR TITLE
Cache and share shapes for pipes

### DIFF
--- a/common/src/main/java/rearth/oritech/block/blocks/interaction/MachineFrameBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/interaction/MachineFrameBlock.java
@@ -12,11 +12,11 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.Oritech;
+import rearth.oritech.block.blocks.pipes.GenericPipeBlock;
 import rearth.oritech.init.TagContent;
 
 import java.util.List;
@@ -59,24 +59,19 @@ public class MachineFrameBlock extends Block {
     }
     
     private VoxelShape getShape(BlockState state) {
-        var shape = boundingShapes[0];
-        
-        if (state.get(NORTH))
-            shape = VoxelShapes.union(shape, boundingShapes[1]);
-        if (state.get(EAST))
-            shape = VoxelShapes.union(shape, boundingShapes[2]);
-        if (state.get(SOUTH))
-            shape = VoxelShapes.union(shape, boundingShapes[3]);
-        if (state.get(WEST))
-            shape = VoxelShapes.union(shape, boundingShapes[4]);
-        if (state.get(UP))
-            shape = VoxelShapes.union(shape, boundingShapes[5]);
-        if (state.get(DOWN))
-            shape = VoxelShapes.union(shape, boundingShapes[6]);
-        
-        return shape;
+        return boundingShapes[packStates(state)];
     }
-    
+
+    private static int packStates(BlockState state) {
+        int i = 0;
+        if (state.get(NORTH)) i |= 1;
+        if (state.get(EAST)) i |= 2;
+        if (state.get(SOUTH)) i |= 4;
+        if (state.get(WEST)) i |= 8;
+        if (state.get(UP)) i |= 16;
+        if (state.get(DOWN)) i |= 32;
+        return i;
+    }
     
     @Override
     public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
@@ -91,15 +86,15 @@ public class MachineFrameBlock extends Block {
     }
     
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(5, 5, 5, 11, 11, 11);
-        VoxelShape north = Block.createCuboidShape(5, 5, 0, 11, 11, 5);
-        VoxelShape east = Block.createCuboidShape(0, 5, 5, 5, 11, 11);
-        VoxelShape south = Block.createCuboidShape(5, 5, 11, 11, 11, 16);
-        VoxelShape west = Block.createCuboidShape(11, 5, 5, 16, 11, 11);
-        VoxelShape up = Block.createCuboidShape(5, 5, 5, 11, 16, 11);
-        VoxelShape down = Block.createCuboidShape(5, 0, 5, 11, 5, 11);
-        
-        return new VoxelShape[] {inner, north, west, south, east, up, down};
+        return GenericPipeBlock.createShapes(
+                Block.createCuboidShape(5, 5, 5, 11, 11, 11),
+                Block.createCuboidShape(5, 5, 0, 11, 11, 5),
+                Block.createCuboidShape(0, 5, 5, 5, 11, 11),
+                Block.createCuboidShape(5, 5, 11, 11, 11, 16),
+                Block.createCuboidShape(11, 5, 5, 16, 11, 11),
+                Block.createCuboidShape(5, 5, 5, 11, 16, 11),
+                Block.createCuboidShape(5, 0, 5, 11, 5, 11)
+        );
     }
     
     @Nullable

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeBlock.java
@@ -10,6 +10,7 @@ import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
@@ -38,7 +39,26 @@ public abstract class GenericPipeBlock extends AbstractPipeBlock implements Wren
     public static final IntProperty UP = IntProperty.of("up", 0, 1);
     public static final IntProperty DOWN = IntProperty.of("down", 0, 1);
     public static final BooleanProperty STRAIGHT = BooleanProperty.of("straight");
-    
+
+    public static final VoxelShape[] THICK_SHAPES = createShapes(
+            Block.createCuboidShape(5, 5, 5, 11, 11, 11),
+            Block.createCuboidShape(5, 5, 0, 11, 11, 5),
+            Block.createCuboidShape(11, 5, 5, 16, 11, 11),
+            Block.createCuboidShape(5, 5, 11, 11, 11, 16),
+            Block.createCuboidShape(0, 5, 5, 5, 11, 11),
+            Block.createCuboidShape(5, 11, 5, 11, 16, 11),
+            Block.createCuboidShape(5, 0, 5, 11, 5, 11)
+    );
+    public static final VoxelShape[] THIN_SHAPES = createShapes(
+            Block.createCuboidShape(6, 6, 6, 10, 10, 10),
+            Block.createCuboidShape(6, 6, 0, 10, 10, 6),
+            Block.createCuboidShape(10, 6, 6, 16, 10, 10),
+            Block.createCuboidShape(6, 6, 10, 10, 10, 16),
+            Block.createCuboidShape(0, 6, 6, 6, 10, 10),
+            Block.createCuboidShape(6, 10, 6, 10, 16, 10),
+            Block.createCuboidShape(6, 0, 6, 10, 6, 10)
+    );
+
     public GenericPipeBlock(Settings settings) {
         super(settings);
         this.setDefaultState(getDefaultState()
@@ -55,36 +75,41 @@ public abstract class GenericPipeBlock extends AbstractPipeBlock implements Wren
     protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
         builder.add(getNorthProperty(), getEastProperty(), getSouthProperty(), getWestProperty(), getUpProperty(), getDownProperty(), STRAIGHT);
     }
-    
+
     protected VoxelShape getShape(BlockState state) {
-        var shape = boundingShapes[0];
-        
-        if (state.get(getNorthProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[1]);
-        if (state.get(getEastProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[2]);
-        if (state.get(getSouthProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[3]);
-        if (state.get(getWestProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[4]);
-        if (state.get(getUpProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[5]);
-        if (state.get(getDownProperty()) != NO_CONNECTION)
-            shape = VoxelShapes.union(shape, boundingShapes[6]);
-        
-        return shape;
+        return boundingShapes[packStates(state)];
     }
     
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(5, 5, 5, 11, 11, 11);
-        VoxelShape north = Block.createCuboidShape(5, 5, 0, 11, 11, 5);
-        VoxelShape east = Block.createCuboidShape(0, 5, 5, 5, 11, 11);
-        VoxelShape south = Block.createCuboidShape(5, 5, 11, 11, 11, 16);
-        VoxelShape west = Block.createCuboidShape(11, 5, 5, 16, 11, 11);
-        VoxelShape up = Block.createCuboidShape(5, 11, 5, 11, 16, 11);
-        VoxelShape down = Block.createCuboidShape(5, 0, 5, 11, 5, 11);
-        
-        return new VoxelShape[]{inner, north, west, south, east, up, down};
+        return THICK_SHAPES;
+    }
+
+    public static VoxelShape[] createShapes(VoxelShape inner, VoxelShape north, VoxelShape east, VoxelShape south, VoxelShape west, VoxelShape up, VoxelShape down) {
+        VoxelShape[] shapes = new VoxelShape[64];
+
+        for (int i = 0; i <= 63; i++) {
+            VoxelShape shape = inner;
+            if ((i & 1) != 0) shape = VoxelShapes.combine(shape, north, BooleanBiFunction.OR);
+            if ((i & 2) != 0) shape = VoxelShapes.combine(shape, east, BooleanBiFunction.OR);
+            if ((i & 4) != 0) shape = VoxelShapes.combine(shape, south, BooleanBiFunction.OR);
+            if ((i & 8) != 0) shape = VoxelShapes.combine(shape, west, BooleanBiFunction.OR);
+            if ((i & 16) != 0) shape = VoxelShapes.combine(shape, up, BooleanBiFunction.OR);
+            if ((i & 32) != 0) shape = VoxelShapes.combine(shape, down, BooleanBiFunction.OR);
+            shapes[i] = shape.simplify();
+        }
+
+        return shapes;
+    }
+
+    private int packStates(BlockState state) {
+        int i = 0;
+        if (state.get(getNorthProperty()) != NO_CONNECTION) i |= 1;
+        if (state.get(getEastProperty()) != NO_CONNECTION) i |= 2;
+        if (state.get(getSouthProperty()) != NO_CONNECTION) i |= 4;
+        if (state.get(getWestProperty()) != NO_CONNECTION) i |= 8;
+        if (state.get(getUpProperty()) != NO_CONNECTION) i |= 16;
+        if (state.get(getDownProperty()) != NO_CONNECTION) i |= 32;
+        return i;
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/energy/EnergyPipeBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/energy/EnergyPipeBlock.java
@@ -50,15 +50,7 @@ public class EnergyPipeBlock extends GenericPipeBlock {
 
     @Override
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(6, 6, 6, 10, 10, 10);
-        VoxelShape north = Block.createCuboidShape(6, 6, 0, 10, 10, 6);
-        VoxelShape east = Block.createCuboidShape(0, 6, 6, 6, 10, 10);
-        VoxelShape south = Block.createCuboidShape(6, 6, 10, 10, 10, 16);
-        VoxelShape west = Block.createCuboidShape(10, 6, 6, 16, 10, 10);
-        VoxelShape up = Block.createCuboidShape(6, 10, 6, 10, 16, 10);
-        VoxelShape down = Block.createCuboidShape(6, 0, 6, 10, 6, 10);
-
-        return new VoxelShape[]{inner, north, west, south, east, up, down};
+        return THIN_SHAPES;
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/energy/EnergyPipeConnectionBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/energy/EnergyPipeConnectionBlock.java
@@ -49,15 +49,7 @@ public class EnergyPipeConnectionBlock extends GenericPipeConnectionBlock {
 
     @Override
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(6, 6, 6, 10, 10, 10);
-        VoxelShape north = Block.createCuboidShape(6, 6, 0, 10, 10, 6);
-        VoxelShape east = Block.createCuboidShape(0, 6, 6, 6, 10, 10);
-        VoxelShape south = Block.createCuboidShape(6, 6, 10, 10, 10, 16);
-        VoxelShape west = Block.createCuboidShape(10, 6, 6, 16, 10, 10);
-        VoxelShape up = Block.createCuboidShape(6, 10, 6, 10, 16, 10);
-        VoxelShape down = Block.createCuboidShape(6, 0, 6, 10, 6, 10);
-
-        return new VoxelShape[]{inner, north, west, south, east, up, down};
+        return THIN_SHAPES;
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/item/ItemPipeBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/item/ItemPipeBlock.java
@@ -65,15 +65,7 @@ public class ItemPipeBlock extends GenericPipeBlock {
     
     @Override
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(6, 6, 6, 10, 10, 10);
-        VoxelShape north = Block.createCuboidShape(6, 6, 0, 10, 10, 6);
-        VoxelShape east = Block.createCuboidShape(0, 6, 6, 6, 10, 10);
-        VoxelShape south = Block.createCuboidShape(6, 6, 10, 10, 10, 16);
-        VoxelShape west = Block.createCuboidShape(10, 6, 6, 16, 10, 10);
-        VoxelShape up = Block.createCuboidShape(6, 10, 6, 10, 16, 10);
-        VoxelShape down = Block.createCuboidShape(6, 0, 6, 10, 6, 10);
-        
-        return new VoxelShape[]{inner, north, west, south, east, up, down};
+        return THIN_SHAPES;
     }
     
     @Override
@@ -126,15 +118,7 @@ public class ItemPipeBlock extends GenericPipeBlock {
         
         @Override
         protected VoxelShape[] createShapes() {
-            VoxelShape inner = Block.createCuboidShape(5, 5, 5, 11, 11, 11);
-            VoxelShape north = Block.createCuboidShape(5, 5, 0, 11, 11, 5);
-            VoxelShape east = Block.createCuboidShape(0, 5, 5, 5, 11, 11);
-            VoxelShape south = Block.createCuboidShape(5, 5, 11, 11, 11, 16);
-            VoxelShape west = Block.createCuboidShape(11, 5, 5, 16, 11, 11);
-            VoxelShape up = Block.createCuboidShape(5, 11, 5, 11, 16, 11);
-            VoxelShape down = Block.createCuboidShape(5, 0, 5, 11, 5, 11);
-            
-            return new VoxelShape[]{inner, north, west, south, east, up, down};
+            return THICK_SHAPES;
         }
         
         @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/item/ItemPipeConnectionBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/item/ItemPipeConnectionBlock.java
@@ -96,15 +96,7 @@ public class ItemPipeConnectionBlock extends ExtractablePipeConnectionBlock {
 
     @Override
     protected VoxelShape[] createShapes() {
-        VoxelShape inner = Block.createCuboidShape(6, 6, 6, 10, 10, 10);
-        VoxelShape north = Block.createCuboidShape(6, 6, 0, 10, 10, 6);
-        VoxelShape east = Block.createCuboidShape(0, 6, 6, 6, 10, 10);
-        VoxelShape south = Block.createCuboidShape(6, 6, 10, 10, 10, 16);
-        VoxelShape west = Block.createCuboidShape(10, 6, 6, 16, 10, 10);
-        VoxelShape up = Block.createCuboidShape(6, 10, 6, 10, 16, 10);
-        VoxelShape down = Block.createCuboidShape(6, 0, 6, 10, 6, 10);
-
-        return new VoxelShape[]{inner, north, west, south, east, up, down};
+        return THIN_SHAPES;
     }
     
     @Override
@@ -167,15 +159,7 @@ public class ItemPipeConnectionBlock extends ExtractablePipeConnectionBlock {
         
         @Override
         protected VoxelShape[] createShapes() {
-            VoxelShape inner = Block.createCuboidShape(5, 5, 5, 11, 11, 11);
-            VoxelShape north = Block.createCuboidShape(5, 5, 0, 11, 11, 5);
-            VoxelShape east = Block.createCuboidShape(0, 5, 5, 5, 11, 11);
-            VoxelShape south = Block.createCuboidShape(5, 5, 11, 11, 11, 16);
-            VoxelShape west = Block.createCuboidShape(11, 5, 5, 16, 11, 11);
-            VoxelShape up = Block.createCuboidShape(5, 11, 5, 11, 16, 11);
-            VoxelShape down = Block.createCuboidShape(5, 0, 5, 11, 5, 11);
-            
-            return new VoxelShape[]{inner, north, west, south, east, up, down};
+            return THICK_SHAPES;
         }
     }
 }


### PR DESCRIPTION
This massively improves collision performance with pipes and also helps world load times, at the cost of a small amount of startup time and a tiny amount of memory usage.
Fixes #418 

A before spark profile is available in that issue. Here is an after spark profile: https://spark.lucko.me/Cc4vQM4Uev?hl=1127
Oritech doesn't even show up. Same test setup.
![image](https://github.com/user-attachments/assets/b77abfaa-9935-4560-8108-b56c29a94367)
