### PR TITLE
Fixes energy api extract on fabric

### DIFF
--- a/fabric/src/main/java/rearth/oritech/fabric/FabricEnergyApiImpl.java
+++ b/fabric/src/main/java/rearth/oritech/fabric/FabricEnergyApiImpl.java
@@ -187,7 +187,16 @@ public class FabricEnergyApiImpl implements BlockEnergyApi, ItemEnergyApi {
                     container.update();
                 }
             });
-            return container.extract(maxAmount, false);
+
+            long extracted = container.extract(maxAmount, false);
+
+            // no idea what this does, but it does seem to fix it
+            if (context != null) {
+                stack.set(EnergyApi.ITEM.getEnergyComponent(), container.getAmount());
+                context.exchange(ItemVariant.of(stack), 1, transaction);
+            }
+
+            return extracted;
         }
         
         @Override

--- a/fabric/src/main/java/rearth/oritech/fabric/FabricEnergyApiImpl.java
+++ b/fabric/src/main/java/rearth/oritech/fabric/FabricEnergyApiImpl.java
@@ -188,7 +188,7 @@ public class FabricEnergyApiImpl implements BlockEnergyApi, ItemEnergyApi {
                 }
             });
 
-            long extracted = container.extract(maxAmount, false);
+            var extracted = container.extract(maxAmount, false);
 
             // no idea what this does, but it does seem to fix it
             if (context != null) {


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

Fixed the problem that the Energy API implementation under Fabric did not update the insert and extract functions at the same time, which may lead to possible energy duplication.

<!--- Remove this if not applicable: -->
Fixes #430 

# How Has This Been Tested?

This PR does not involve the common part, but only fixes the energy api of Fabric, so it is only tested on Fabric.

I have tested the scenario of this issue, used Portable Energy Storage and the battery plug-in to try to charge and discharge the backpack and Portable Energy Storage. No obvious abnormalities were found.

- [ ] Feature has been tested ingame on both neoforge and fabric.
- [x] Optional additional testing details

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas