### PR TITLE
Add missing overide

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/processing/FragmentForgeBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/processing/FragmentForgeBlockEntity.java
@@ -77,7 +77,13 @@ public class FragmentForgeBlockEntity extends MultiblockMachineEntity {
         super.resetAddons();
         hasByproductAddon = false;
     }
-    
+
+    @Override
+    public void gatherAddonStats(List<AddonBlock> addons) {
+        hasByproductAddon = false;
+        super.gatherAddonStats(addons);
+    }
+
     @Override
     protected void writeNbt(NbtCompound nbt, RegistryWrapper.WrapperLookup registryLookup) {
         super.writeNbt(nbt, registryLookup);


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

Due to the lack of corresponding override, the Boolean value associated with the yield addon was not reset after it was removed. I highly doubt whether other machines have similar problems

<!--- Remove this if not applicable: -->
Fixes #464 

# How Has This Been Tested?

The two platforms have been tested. Since the change involved is only one line of code, I will not describe the details.

- [x] Feature has been tested ingame on both neoforge and fabric.
- [ ] Optional additional testing details

# Checklist:

- [ ] My code uses the 'var' keyword where applicable.
- [ ] I have commented my code, particularly in hard-to-understand areas