### PR TITLE
Fixed wrong multiplier

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/processing/RefineryBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/processing/RefineryBlockEntity.java
@@ -169,7 +169,7 @@ public class RefineryBlockEntity extends MultiblockMachineEntity implements Flui
     }
     
     private int getItemOutputMultiplier() {
-        return getModuleCount() == 0 ? 2 : 1;
+        return getModuleCount() == 0 ? 1 : 2;
     }
     
     @Override


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

The expression of the multiplier is written in reverse, resulting in an incorrect output multiplier

<!--- Remove this if not applicable: -->
Fixes #466 

# How Has This Been Tested?

I'm not very good at using this new machine, so I just did a simple test on NeoForge. It looks like it's fixed.

- [ ] Feature has been tested ingame on both neoforge and fabric.
- [ ] Optional additional testing details

# Checklist:

- [ ] My code uses the 'var' keyword where applicable.
- [ ] I have commented my code, particularly in hard-to-understand areas