### PR TITLE
Item Filter Ghost Handlers

### DIFF
--- a/common/src/main/java/rearth/oritech/client/ui/ItemFilterScreen.java
+++ b/common/src/main/java/rearth/oritech/client/ui/ItemFilterScreen.java
@@ -22,11 +22,13 @@ import java.util.function.Predicate;
 import static rearth.oritech.client.ui.BasicMachineScreen.ITEM_SLOT;
 
 public class ItemFilterScreen extends BaseOwoHandledScreen<FlowLayout, ItemFilterScreenHandler> {
-    
+
+    public static final int FILTER_SIZE = 12;
+
     private ButtonComponent whiteListButton;
     private ButtonComponent nbtButton;
     private ButtonComponent componentButton;
-    private final FlowLayout[] gridContainers = new FlowLayout[12];
+    private final FlowLayout[] gridContainers = new FlowLayout[FILTER_SIZE];
     private Map<Integer, ItemStack> cachedItems;
     
     public ItemFilterScreen(ItemFilterScreenHandler handler, PlayerInventory inventory, Text title) {
@@ -43,7 +45,7 @@ public class ItemFilterScreen extends BaseOwoHandledScreen<FlowLayout, ItemFilte
         cachedItems = handler.blockEntity.getFilterSettings().items();
         Oritech.LOGGER.debug("loading item filters: " + cachedItems);
         
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < FILTER_SIZE; i++) {
             var storedStack = cachedItems.getOrDefault(i, ItemStack.EMPTY);
             
             var container = gridContainers[i];

--- a/common/src/main/java/rearth/oritech/client/ui/ItemFilterScreen.java
+++ b/common/src/main/java/rearth/oritech/client/ui/ItemFilterScreen.java
@@ -101,8 +101,8 @@ public class ItemFilterScreen extends BaseOwoHandledScreen<FlowLayout, ItemFilte
         for (int x = 0; x < 4; x++) {
             for (int y = 0; y < 3; y++) {
                 
-                var slotContainer = Containers.horizontalFlow(Sizing.fixed(19), Sizing.fixed(18));
-                var background = Components.texture(ITEM_SLOT, 0, 0, 18, 17, 18, 17).positioning(Positioning.absolute(0, 0));
+                var slotContainer = Containers.horizontalFlow(Sizing.fixed(18), Sizing.fixed(18));
+                var background = Components.texture(ITEM_SLOT, 0, 0, 18, 18, 18, 18).positioning(Positioning.absolute(0, 0));
                 
                 int finalX = x;
                 int finalY = y;
@@ -111,7 +111,7 @@ public class ItemFilterScreen extends BaseOwoHandledScreen<FlowLayout, ItemFilte
                 slotContainer.child(background);
                 var idIndex = y * 4 + x;
                 gridContainers[idIndex] = slotContainer;
-                gridContainer.child(slotContainer.margins(Insets.of(0, 2, 0, 0)), y, x);
+                gridContainer.child(slotContainer.margins(Insets.of(0, 2, 0, 1)), y, x);
                 
             }
         }
@@ -216,47 +216,55 @@ public class ItemFilterScreen extends BaseOwoHandledScreen<FlowLayout, ItemFilte
     }
     
     private boolean onItemFrameBackgroundClicked(FlowLayout slotContainer, int x, int y) {
-        
+        return acceptItemStack(slotContainer, this.handler.getCursorStack(), y * 4 + x);
+    }
+
+    public boolean acceptItemStack(ItemStack itemStack, int index) {
+        return acceptItemStack(getItemContainer(index), itemStack, index);
+    }
+
+    public boolean acceptItemStack(FlowLayout slotContainer, ItemStack itemStack, int index) {
         if (slotContainer.children().size() >= 2) {
             slotContainer.removeChild(slotContainer.children().get(1));
         }
-        
-        var heldItem = this.handler.getCursorStack();
-        if (heldItem.isEmpty()) {
-            
-            var idIndex = y * 4 + x;
+
+        if (itemStack.isEmpty()) {
+
             var oldData = handler.blockEntity.getFilterSettings();
             var itemFilters = new HashMap<>(oldData.items());
-            itemFilters.remove(idIndex);
+            itemFilters.remove(index);
             var newData = new ItemFilterBlockEntity.FilterData(oldData.useNbt(), oldData.useWhitelist(), oldData.useComponents(), itemFilters);
             updateFilterSettings(newData); // this is only on client
             sendUpdateToServer();
-            
+
             return false;
         }
-        
-        var displayStack = new ItemStack(heldItem.getItem(), 1);
-        
-        if (heldItem.getComponents() != null)
-            displayStack.applyComponentsFrom(heldItem.getComponents());
-        
+
+        var displayStack = new ItemStack(itemStack.getItem(), 1);
+
+        if (itemStack.getComponents() != null)
+            displayStack.applyComponentsFrom(itemStack.getComponents());
+
         var itemComponent = Components.item(displayStack);
         itemComponent.positioning(Positioning.absolute(1, 1));
         itemComponent.showOverlay(true);
         itemComponent.setTooltipFromStack(true);
         slotContainer.child(itemComponent);
-        
-        var idIndex = y * 4 + x;
+
         var oldData = handler.blockEntity.getFilterSettings();
         var itemFilters = new HashMap<>(oldData.items());
-        itemFilters.put(idIndex, displayStack);
+        itemFilters.put(index, displayStack);
         var newData = new ItemFilterBlockEntity.FilterData(oldData.useNbt(), oldData.useWhitelist(), oldData.useComponents(), itemFilters);
         updateFilterSettings(newData); // this is only on client
-        
+
         Oritech.LOGGER.debug("stored map: " + itemFilters);
         sendUpdateToServer();
-        
+
         return true;
+    }
+
+    public FlowLayout getItemContainer(int index) {
+        return gridContainers[index];
     }
 
     private void updateFilterSettings(ItemFilterBlockEntity.FilterData filterData) {

--- a/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
@@ -5,10 +5,12 @@ import dev.emi.emi.api.stack.EmiIngredient;
 import net.minecraft.client.gui.DrawContext;
 import rearth.oritech.client.ui.ItemFilterScreen;
 
+import static rearth.oritech.client.ui.ItemFilterScreen.FILTER_SIZE;
+
 public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilterScreen> {
     @Override
     public void render(ItemFilterScreen screen, EmiIngredient dragged, DrawContext draw, int mouseX, int mouseY, float delta) {
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < FILTER_SIZE; i++) {
             var container = screen.getItemContainer(i);
             draw.fill(container.x(), container.y(), container.x() + container.width(), container.y() + container.height(), 0x8822BB33);
         }
@@ -20,7 +22,7 @@ public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilt
             return false;
         }
 
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < FILTER_SIZE; i++) {
             var container = screen.getItemContainer(i);
             if (container.isInBoundingBox(x, y)) {
                 return screen.acceptItemStack(stack.getEmiStacks().getFirst().getItemStack().copyWithCount(1), i);

--- a/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
@@ -1,0 +1,23 @@
+package rearth.oritech.init.compat.emi;
+
+import dev.emi.emi.api.EmiDragDropHandler;
+import dev.emi.emi.api.stack.EmiIngredient;
+import io.wispforest.owo.ui.container.FlowLayout;
+import rearth.oritech.client.ui.ItemFilterScreen;
+
+public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilterScreen> {
+    @Override
+    public boolean dropStack(ItemFilterScreen screen, EmiIngredient stack, int x, int y) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        for (int i = 0; i < 12; i++) {
+            FlowLayout container = screen.getItemContainer(i);
+            if (container.isInBoundingBox(x, y)) {
+                return screen.acceptItemStack(stack.getEmiStacks().getFirst().getItemStack().copyWithCount(1), i);
+            }
+        }
+        return false;
+    }
+}

--- a/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
@@ -2,7 +2,6 @@ package rearth.oritech.init.compat.emi;
 
 import dev.emi.emi.api.EmiDragDropHandler;
 import dev.emi.emi.api.stack.EmiIngredient;
-import io.wispforest.owo.ui.container.FlowLayout;
 import net.minecraft.client.gui.DrawContext;
 import rearth.oritech.client.ui.ItemFilterScreen;
 
@@ -10,7 +9,7 @@ public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilt
     @Override
     public void render(ItemFilterScreen screen, EmiIngredient dragged, DrawContext draw, int mouseX, int mouseY, float delta) {
         for (int i = 0; i < 12; i++) {
-            FlowLayout container = screen.getItemContainer(i);
+            var container = screen.getItemContainer(i);
             draw.fill(container.x(), container.y(), container.x() + container.width(), container.y() + container.height(), 0x8822BB33);
         }
     }
@@ -22,7 +21,7 @@ public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilt
         }
 
         for (int i = 0; i < 12; i++) {
-            FlowLayout container = screen.getItemContainer(i);
+            var container = screen.getItemContainer(i);
             if (container.isInBoundingBox(x, y)) {
                 return screen.acceptItemStack(stack.getEmiStacks().getFirst().getItemStack().copyWithCount(1), i);
             }

--- a/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/emi/EmiItemFilterDragDropHandler.java
@@ -3,9 +3,18 @@ package rearth.oritech.init.compat.emi;
 import dev.emi.emi.api.EmiDragDropHandler;
 import dev.emi.emi.api.stack.EmiIngredient;
 import io.wispforest.owo.ui.container.FlowLayout;
+import net.minecraft.client.gui.DrawContext;
 import rearth.oritech.client.ui.ItemFilterScreen;
 
 public class EmiItemFilterDragDropHandler implements EmiDragDropHandler<ItemFilterScreen> {
+    @Override
+    public void render(ItemFilterScreen screen, EmiIngredient dragged, DrawContext draw, int mouseX, int mouseY, float delta) {
+        for (int i = 0; i < 12; i++) {
+            FlowLayout container = screen.getItemContainer(i);
+            draw.fill(container.x(), container.y(), container.x() + container.width(), container.y() + container.height(), 0x8822BB33);
+        }
+    }
+
     @Override
     public boolean dropStack(ItemFilterScreen screen, EmiIngredient stack, int x, int y) {
         if (stack.isEmpty()) {

--- a/common/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
+++ b/common/src/main/java/rearth/oritech/init/compat/emi/OritechEMIPlugin.java
@@ -17,6 +17,7 @@ import rearth.oritech.block.entity.generators.LavaGeneratorEntity;
 import rearth.oritech.block.entity.generators.SteamEngineEntity;
 import rearth.oritech.block.entity.processing.*;
 import rearth.oritech.client.init.ModScreens;
+import rearth.oritech.client.ui.ItemFilterScreen;
 import rearth.oritech.init.BlockContent;
 import rearth.oritech.init.recipes.OritechRecipeType;
 import rearth.oritech.init.recipes.RecipeContent;
@@ -60,7 +61,8 @@ public class OritechEMIPlugin implements EmiPlugin {
         registry.addRecipeHandler(ModScreens.ASSEMBLER_SCREEN, new EmiTransferHandler<>(RecipeContent.ASSEMBLER.getIdentifier()));
         registry.addRecipeHandler(ModScreens.FOUNDRY_SCREEN, new EmiTransferHandler<>(RecipeContent.FOUNDRY.getIdentifier()));
         registry.addRecipeHandler(ModScreens.ATOMIC_FORGE_SCREEN, new EmiTransferHandler<>(RecipeContent.ATOMIC_FORGE.getIdentifier()));
-        
+
+        registry.addDragDropHandler(ItemFilterScreen.class, new EmiItemFilterDragDropHandler());
     }
     
     private void registerOritechCategory(EmiRegistry registry, RecipeManager manager, OritechRecipeType recipeType, ItemConvertible machine,  Class<? extends MachineBlockEntity> screenProviderSource) {

--- a/common/src/main/java/rearth/oritech/init/compat/jei/JeiExclusionZoneHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/JeiExclusionZoneHandler.java
@@ -1,0 +1,46 @@
+package rearth.oritech.init.compat.jei;
+
+import io.wispforest.owo.mixin.ui.access.BaseOwoHandledScreenAccessor;
+import io.wispforest.owo.ui.base.BaseOwoHandledScreen;
+import io.wispforest.owo.ui.container.FlowLayout;
+import io.wispforest.owo.ui.core.Component;
+import io.wispforest.owo.ui.core.OwoUIAdapter;
+import io.wispforest.owo.ui.core.ParentComponent;
+import io.wispforest.owo.ui.core.Size;
+import io.wispforest.owo.ui.core.Surface;
+import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import net.minecraft.client.util.math.Rect2i;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class JeiExclusionZoneHandler implements IGuiContainerHandler<BaseOwoHandledScreen<FlowLayout, ?>> {
+    @Override
+    public @NotNull List<Rect2i> getGuiExtraAreas(@NotNull BaseOwoHandledScreen<FlowLayout, ?> containerScreen) {
+        var result = new ArrayList<Rect2i>();
+
+        // basically a copy of the owo emi adapter
+        if (!containerScreen.children().isEmpty() && containerScreen instanceof BaseOwoHandledScreenAccessor accessor) {
+            OwoUIAdapter<?> adapter = accessor.owo$getUIAdapter();
+            if (adapter != null) {
+                ParentComponent rootComponent = adapter.rootComponent;
+                ArrayList<Component> children = new ArrayList<>();
+                rootComponent.collectDescendants(children);
+                children.remove(rootComponent);
+                children.forEach((component) -> {
+                    if (component instanceof ParentComponent parent) {
+                        if (parent.surface() == Surface.BLANK) {
+                            return;
+                        }
+                    }
+
+                    Size size = component.fullSize();
+                    result.add(new Rect2i(component.x(), component.y(), size.width(), size.height()));
+                });
+            }
+        }
+
+        return result;
+    }
+}

--- a/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
@@ -11,6 +11,8 @@ import rearth.oritech.client.ui.ItemFilterScreen;
 import java.util.ArrayList;
 import java.util.List;
 
+import static rearth.oritech.client.ui.ItemFilterScreen.FILTER_SIZE;
+
 class JeiItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScreen> {
 
     @Override
@@ -20,7 +22,7 @@ class JeiItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScr
             return targets;
         }
 
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < FILTER_SIZE; i++) {
             targets.add(new ItemFilterTarget<>(screen, i));
         }
         return targets;

--- a/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
@@ -1,0 +1,55 @@
+package rearth.oritech.init.compat.jei;
+
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.util.math.Rect2i;
+import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import rearth.oritech.client.ui.ItemFilterScreen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class JeiItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScreen> {
+
+    @Override
+    public <I> @NotNull List<Target<I>> getTargetsTyped(@NotNull ItemFilterScreen screen, @NotNull ITypedIngredient<I> ingredient, boolean doStart) {
+        List<Target<I>> targets = new ArrayList<>();
+        if (ingredient.getType() != VanillaTypes.ITEM_STACK) {
+            return targets;
+        }
+
+        for (int i = 0; i < 12; i++) {
+            targets.add(new ItemFilterTarget<>(screen, i));
+        }
+        return targets;
+    }
+
+    @Override
+    public void onComplete() {}
+
+    static final class ItemFilterTarget<I> implements Target<I> {
+        private final ItemFilterScreen screen;
+        private final int index;
+        private final Rect2i area;
+
+        ItemFilterTarget(ItemFilterScreen screen, int index) {
+            this.screen = screen;
+            this.index = index;
+
+            var container = screen.getItemContainer(index);
+            this.area = new Rect2i(container.x(), container.y(), container.width(), container.height());
+        }
+
+        @Override
+        public @NotNull Rect2i getArea() {
+            return area;
+        }
+
+        @Override
+        public void accept(@NotNull I itemStack) {
+            screen.acceptItemStack(((ItemStack) itemStack).copyWithCount(1), index);
+        }
+    }
+}

--- a/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/JeiItemFilterGhostHandler.java
@@ -17,7 +17,7 @@ class JeiItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScr
 
     @Override
     public <I> @NotNull List<Target<I>> getTargetsTyped(@NotNull ItemFilterScreen screen, @NotNull ITypedIngredient<I> ingredient, boolean doStart) {
-        List<Target<I>> targets = new ArrayList<>();
+        var targets = new ArrayList<Target<I>>();
         if (ingredient.getType() != VanillaTypes.ITEM_STACK) {
             return targets;
         }

--- a/common/src/main/java/rearth/oritech/init/compat/jei/OritechJeiPlugin.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/OritechJeiPlugin.java
@@ -1,15 +1,7 @@
 package rearth.oritech.init.compat.jei;
 
-import io.wispforest.owo.mixin.ui.access.BaseOwoHandledScreenAccessor;
-import io.wispforest.owo.ui.base.BaseOwoHandledScreen;
-import io.wispforest.owo.ui.container.FlowLayout;
-import io.wispforest.owo.ui.core.*;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
-import mezz.jei.api.constants.VanillaTypes;
-import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
-import mezz.jei.api.gui.handlers.IGuiContainerHandler;
-import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
@@ -17,8 +9,6 @@ import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.block.Block;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.util.math.Rect2i;
-import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +30,6 @@ import rearth.oritech.init.recipes.RecipeContent;
 import rearth.oritech.util.InventorySlotAssignment;
 import rearth.oritech.util.ScreenProvider;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @JeiPlugin
@@ -156,83 +145,7 @@ public class OritechJeiPlugin implements IModPlugin {
         registration.addGenericGuiContainerHandler(ReactorScreen.class, new JeiExclusionZoneHandler());
         registration.addGenericGuiContainerHandler(PlayerModifierScreen.class, new JeiExclusionZoneHandler());
 
-        registration.addGhostIngredientHandler(ItemFilterScreen.class, new ItemFilterGhostHandler());
-    }
-    
-    private static class JeiExclusionZoneHandler implements IGuiContainerHandler<BaseOwoHandledScreen<FlowLayout, ?>> {
-        @Override
-        public @NotNull List<Rect2i> getGuiExtraAreas(@NotNull BaseOwoHandledScreen<FlowLayout, ?> containerScreen) {
-            return getScreenExclusionZones(containerScreen);
-        }
-    }
-    
-    private static @NotNull ArrayList<Rect2i> getScreenExclusionZones(@NotNull BaseOwoHandledScreen<FlowLayout, ?> containerScreen) {
-        var result = new ArrayList<Rect2i>();
-        
-        // basically a copy of the owo emi adapter
-        if (!containerScreen.children().isEmpty() && containerScreen instanceof BaseOwoHandledScreenAccessor accessor) {
-            OwoUIAdapter<?> adapter = accessor.owo$getUIAdapter();
-            if (adapter != null) {
-                ParentComponent rootComponent = adapter.rootComponent;
-                ArrayList<Component> children = new ArrayList<>();
-                rootComponent.collectDescendants(children);
-                children.remove(rootComponent);
-                children.forEach((component) -> {
-                    if (component instanceof ParentComponent parent) {
-                        if (parent.surface() == Surface.BLANK) {
-                            return;
-                        }
-                    }
-                    
-                    Size size = component.fullSize();
-                    result.add(new Rect2i(component.x(), component.y(), size.width(), size.height()));
-                });
-            }
-        }
-        
-        return result;
+        registration.addGhostIngredientHandler(ItemFilterScreen.class, new JeiItemFilterGhostHandler());
     }
 
-    private static class ItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScreen> {
-
-        @Override
-        public <I> @NotNull List<Target<I>> getTargetsTyped(@NotNull ItemFilterScreen screen, @NotNull ITypedIngredient<I> ingredient, boolean doStart) {
-            List<Target<I>> targets = new ArrayList<>();
-            if (ingredient.getType() != VanillaTypes.ITEM_STACK) {
-                return targets;
-            }
-
-            for (int i = 0; i < 12; i++) {
-                targets.add(new ItemFilterTarget<>(screen, i));
-            }
-            return targets;
-        }
-
-        @Override
-        public void onComplete() {}
-
-        static final class ItemFilterTarget<I> implements Target<I> {
-            private final ItemFilterScreen screen;
-            private final int index;
-            private final Rect2i area;
-
-            ItemFilterTarget(ItemFilterScreen screen, int index) {
-                this.screen = screen;
-                this.index = index;
-
-                var layout = screen.getItemContainer(index);
-                this.area = new Rect2i(layout.x(), layout.y(), layout.width(), layout.height());
-            }
-
-            @Override
-            public @NotNull Rect2i getArea() {
-                return area;
-            }
-
-            @Override
-            public void accept(@NotNull I itemStack) {
-                screen.acceptItemStack(((ItemStack) itemStack).copyWithCount(1), index);
-            }
-        }
-    }
 }

--- a/common/src/main/java/rearth/oritech/init/compat/jei/OritechJeiPlugin.java
+++ b/common/src/main/java/rearth/oritech/init/compat/jei/OritechJeiPlugin.java
@@ -6,7 +6,10 @@ import io.wispforest.owo.ui.container.FlowLayout;
 import io.wispforest.owo.ui.core.*;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
 import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
@@ -15,6 +18,7 @@ import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.block.Block;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.Rect2i;
+import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.RecipeEntry;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +30,7 @@ import rearth.oritech.block.entity.generators.LavaGeneratorEntity;
 import rearth.oritech.block.entity.generators.SteamEngineEntity;
 import rearth.oritech.block.entity.processing.*;
 import rearth.oritech.client.ui.BasicMachineScreen;
+import rearth.oritech.client.ui.ItemFilterScreen;
 import rearth.oritech.client.ui.PlayerModifierScreen;
 import rearth.oritech.client.ui.ReactorScreen;
 import rearth.oritech.init.BlockContent;
@@ -150,7 +155,8 @@ public class OritechJeiPlugin implements IModPlugin {
         registration.addGenericGuiContainerHandler(BasicMachineScreen.class, new JeiExclusionZoneHandler());
         registration.addGenericGuiContainerHandler(ReactorScreen.class, new JeiExclusionZoneHandler());
         registration.addGenericGuiContainerHandler(PlayerModifierScreen.class, new JeiExclusionZoneHandler());
-        
+
+        registration.addGhostIngredientHandler(ItemFilterScreen.class, new ItemFilterGhostHandler());
     }
     
     private static class JeiExclusionZoneHandler implements IGuiContainerHandler<BaseOwoHandledScreen<FlowLayout, ?>> {
@@ -185,5 +191,48 @@ public class OritechJeiPlugin implements IModPlugin {
         }
         
         return result;
+    }
+
+    private static class ItemFilterGhostHandler implements IGhostIngredientHandler<ItemFilterScreen> {
+
+        @Override
+        public <I> @NotNull List<Target<I>> getTargetsTyped(@NotNull ItemFilterScreen screen, @NotNull ITypedIngredient<I> ingredient, boolean doStart) {
+            List<Target<I>> targets = new ArrayList<>();
+            if (ingredient.getType() != VanillaTypes.ITEM_STACK) {
+                return targets;
+            }
+
+            for (int i = 0; i < 12; i++) {
+                targets.add(new ItemFilterTarget<>(screen, i));
+            }
+            return targets;
+        }
+
+        @Override
+        public void onComplete() {}
+
+        static final class ItemFilterTarget<I> implements Target<I> {
+            private final ItemFilterScreen screen;
+            private final int index;
+            private final Rect2i area;
+
+            ItemFilterTarget(ItemFilterScreen screen, int index) {
+                this.screen = screen;
+                this.index = index;
+
+                var layout = screen.getItemContainer(index);
+                this.area = new Rect2i(layout.x(), layout.y(), layout.width(), layout.height());
+            }
+
+            @Override
+            public @NotNull Rect2i getArea() {
+                return area;
+            }
+
+            @Override
+            public void accept(@NotNull I itemStack) {
+                screen.acceptItemStack(((ItemStack) itemStack).copyWithCount(1), index);
+            }
+        }
     }
 }

--- a/common/src/main/java/rearth/oritech/init/compat/rei/OritechREIPlugin.java
+++ b/common/src/main/java/rearth/oritech/init/compat/rei/OritechREIPlugin.java
@@ -4,6 +4,7 @@ import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
 import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry;
+import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.util.EntryStacks;
@@ -95,7 +96,12 @@ public class OritechREIPlugin implements REIClientPlugin {
         registerMachineRecipeType(registry, RecipeContent.LASER);
         registerMachineRecipeType(registry, RecipeContent.REACTOR);
     }
-    
+
+    @Override
+    public void registerScreens(ScreenRegistry registry) {
+        registry.registerDraggableStackVisitor(new ReiItemFilterDraggableStackVisitor());
+    }
+
     private void registerOritechCategory(CategoryRegistry registry, OritechRecipeType recipeType, ItemConvertible machineIcon, BiFunction<OritechRecipeType, ItemConvertible, ? extends DisplayCategory<Display>> screenType) {
         var oriCategory = screenType.apply(recipeType, machineIcon);
         registry.add(oriCategory);

--- a/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
+++ b/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
@@ -1,0 +1,48 @@
+package rearth.oritech.init.compat.rei;
+
+import io.wispforest.owo.ui.container.FlowLayout;
+import me.shedaniel.math.Rectangle;
+import me.shedaniel.rei.api.client.gui.drag.DraggableStack;
+import me.shedaniel.rei.api.client.gui.drag.DraggableStackVisitor;
+import me.shedaniel.rei.api.client.gui.drag.DraggedAcceptorResult;
+import me.shedaniel.rei.api.client.gui.drag.DraggingContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.item.ItemStack;
+import rearth.oritech.client.ui.ItemFilterScreen;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class ReiItemFilterDraggableStackVisitor implements DraggableStackVisitor<ItemFilterScreen> {
+
+    @Override
+    public DraggedAcceptorResult acceptDraggedStack(DraggingContext<ItemFilterScreen> context, DraggableStack stack) {
+        var cursor = context.getCurrentPosition();
+        if (cursor == null || !(stack.getStack().getValue() instanceof ItemStack itemStack)) {
+            return DraggedAcceptorResult.PASS;
+        }
+
+        var screen = context.getScreen();
+        for (int i = 0; i < 12; i++) {
+            FlowLayout container = screen.getItemContainer(i);
+            if (container.isInBoundingBox(cursor.x, cursor.y)) {
+                return screen.acceptItemStack(itemStack.copyWithCount(1), i)
+                        ? DraggedAcceptorResult.ACCEPTED
+                        : DraggedAcceptorResult.PASS;
+            }
+        }
+        return DraggedAcceptorResult.PASS;
+    }
+
+    @Override
+    public Stream<BoundsProvider> getDraggableAcceptingBounds(DraggingContext<ItemFilterScreen> context, DraggableStack stack) {
+        return IntStream.range(0, 12)
+                .mapToObj(i -> context.getScreen().getItemContainer(i))
+                .map(container -> BoundsProvider.ofRectangle(new Rectangle(container.x(), container.y(), container.width(), container.height())));
+    }
+
+    @Override
+    public <R extends Screen> boolean isHandingScreen(R r) {
+        return r instanceof ItemFilterScreen;
+    }
+}

--- a/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
+++ b/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
@@ -1,6 +1,5 @@
 package rearth.oritech.init.compat.rei;
 
-import io.wispforest.owo.ui.container.FlowLayout;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.client.gui.drag.DraggableStack;
 import me.shedaniel.rei.api.client.gui.drag.DraggableStackVisitor;
@@ -13,6 +12,8 @@ import rearth.oritech.client.ui.ItemFilterScreen;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static rearth.oritech.client.ui.ItemFilterScreen.FILTER_SIZE;
+
 public class ReiItemFilterDraggableStackVisitor implements DraggableStackVisitor<ItemFilterScreen> {
 
     @Override
@@ -23,7 +24,7 @@ public class ReiItemFilterDraggableStackVisitor implements DraggableStackVisitor
         }
 
         var screen = context.getScreen();
-        for (int i = 0; i < 12; i++) {
+        for (int i = 0; i < FILTER_SIZE; i++) {
             var container = screen.getItemContainer(i);
             if (container.isInBoundingBox(cursor.x, cursor.y)) {
                 return screen.acceptItemStack(itemStack.copyWithCount(1), i)
@@ -36,7 +37,7 @@ public class ReiItemFilterDraggableStackVisitor implements DraggableStackVisitor
 
     @Override
     public Stream<BoundsProvider> getDraggableAcceptingBounds(DraggingContext<ItemFilterScreen> context, DraggableStack stack) {
-        return IntStream.range(0, 12)
+        return IntStream.range(0, FILTER_SIZE)
                 .mapToObj(i -> context.getScreen().getItemContainer(i))
                 .map(container -> BoundsProvider.ofRectangle(new Rectangle(container.x(), container.y(), container.width(), container.height())));
     }

--- a/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
+++ b/common/src/main/java/rearth/oritech/init/compat/rei/ReiItemFilterDraggableStackVisitor.java
@@ -24,7 +24,7 @@ public class ReiItemFilterDraggableStackVisitor implements DraggableStackVisitor
 
         var screen = context.getScreen();
         for (int i = 0; i < 12; i++) {
-            FlowLayout container = screen.getItemContainer(i);
+            var container = screen.getItemContainer(i);
             if (container.isInBoundingBox(cursor.x, cursor.y)) {
                 return screen.acceptItemStack(itemStack.copyWithCount(1), i)
                         ? DraggedAcceptorResult.ACCEPTED


### PR DESCRIPTION
# Description
Adds the relevant handlers for JEI, REI, and EMI allowing dragging items into the filter screen.
Added `ItemFilterScreen#FILTER_SIZE` to use instead of using 12 all over.
Added `ItemFilterScreen#acceptItemStack` and moved most logic from the click handler to it for common use.
Made the slot containers 18x18 instead of 19x18 and compensated by adding 1 to the margin instead.
Fixed the filter slots background only being 17 pixels instead of 18.

Moved `JeiExclusionZoneHandler` to a dedicated class file to match other recipe plugin standards, the ghost handler is in its own file as well.

Implements #422 

# How Has This Been Tested?
- [x] Tested Clientside Fabric
- [ ] Tested Clientside NeoForge
- [ ] Tested Dedicated Server Fabric
- [ ] Tested Dedicated Server NeoForge

# Checklist:
- [x] My code uses the 'var' keyword where applicable.
- [x] N/A ~~I have commented my code, particularly in hard-to-understand areas~~