### PR TITLE
Fix fluid detection

### DIFF
--- a/common/src/main/java/rearth/oritech/block/behavior/LaserArmBlockBehavior.java
+++ b/common/src/main/java/rearth/oritech/block/behavior/LaserArmBlockBehavior.java
@@ -110,7 +110,7 @@ public class LaserArmBlockBehavior {
                 if (world.getTime() % 40 == 0) {    // periodically reset target
                     return false;
                 }
-                if (blockState.isAir() || blockState.getFluidState().isStill()) return false;
+                if (blockState.isAir() || !blockState.getFluidState().isEmpty()) return false;
                 
                 blockState.randomTick((ServerWorld) world, blockPos, world.random);
                 ParticleContent.ACCELERATING.spawn(world, Vec3d.of(blockPos));

--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/BlackHoleBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/BlackHoleBlockEntity.java
@@ -55,7 +55,7 @@ public class BlackHoleBlockEntity extends NetworkedBlockEntity implements Networ
         
         for (var candidate : BlockPos.iterateOutwards(pos, pullRange, pullRange, pullRange)) {
             var candidateState = world.getBlockState(candidate);
-            if (candidate.equals(pos) || candidateState.isAir() || candidateState.isIn(TagContent.BLACK_HOLE_BLACKLIST) || candidateState.getFluidState().isStill() || candidateState.getBlock().equals(Blocks.MOVING_PISTON) || candidateState.getBlock().equals(BlockContent.BLACK_HOLE_BLOCK))
+            if (candidate.equals(pos) || candidateState.isAir() || candidateState.isIn(TagContent.BLACK_HOLE_BLACKLIST) || !candidateState.getFluidState().isEmpty() || candidateState.getBlock().equals(Blocks.MOVING_PISTON) || candidateState.getBlock().equals(BlockContent.BLACK_HOLE_BLOCK))
                 continue;
             
             currentlyPullingFrom = candidate;
@@ -152,7 +152,7 @@ public class BlackHoleBlockEntity extends NetworkedBlockEntity implements Networ
     
     private static boolean canPassThrough(BlockState state, BlockPos blockPos) {
         // When targetting entities, don't let grass, vines, small mushrooms, pressure plates, etc. get in the way of the laser
-        return state.isAir() || state.getFluidState().isStill() || state.isIn(TagContent.LASER_PASSTHROUGH) || state.getBlock() instanceof AcceleratorPassthroughBlock;
+        return state.isAir() || !state.getFluidState().isEmpty() || state.isIn(TagContent.LASER_PASSTHROUGH) || state.getBlock() instanceof AcceleratorPassthroughBlock;
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/DestroyerBlockEntity.java
@@ -156,7 +156,7 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
         for (int i = 1; i <= range; i++) {
             var checkPos = toolPosition.down(i);
             var targetState = world.getBlockState(checkPos);
-            if (!targetState.isAir() && !targetState.getFluidState().isStill()) {  // pass through both air and liquid
+            if (!targetState.isAir() && targetState.getFluidState().isEmpty()) {  // pass through both air and liquid
                 quarryTarget = checkPos;
                 targetHardness = Math.clamp(targetState.getHardness(world, checkPos), 0, 100);
                 return new Pair<>(checkPos, targetState);
@@ -186,7 +186,7 @@ public class DestroyerBlockEntity extends MultiblockFrameInteractionEntity {
         }
 
         // remove fluids
-        if (targetState.getFluidState().isStill()) {
+        if (!targetState.getFluidState().isEmpty()) {
             world.setBlockState(targetPosition, Blocks.AIR.getDefaultState());
         }
 

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/LaserArmBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/LaserArmBlockEntity.java
@@ -452,7 +452,7 @@ public class LaserArmBlockEntity extends NetworkedBlockEntity implements
     
     public boolean canPassThrough(BlockState state, BlockPos blockPos) {
         // When targetting entities, don't let grass, vines, small mushrooms, pressure plates, etc. get in the way of the laser
-        return state.isAir() || state.getFluidState().isStill() || state.isIn(TagContent.LASER_PASSTHROUGH) || (hunterAddons > 0 && !state.isSolidBlock(world, blockPos));
+        return state.isAir() || !state.getFluidState().isEmpty() || state.isIn(TagContent.LASER_PASSTHROUGH) || (hunterAddons > 0 && !state.isSolidBlock(world, blockPos));
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/entity/interaction/PumpBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/PumpBlockEntity.java
@@ -105,7 +105,8 @@ public class PumpBlockEntity extends NetworkedBlockEntity implements FluidApi.Bl
             if (pendingLiquidPositions.isEmpty() || tankIsFull()) return;
             
             var targetBlock = pendingLiquidPositions.peekLast();
-            
+
+            // Only drain the source (still) fluid, so it doesn't keep pumping infinitely
             if (!world.getBlockState(targetBlock).getFluidState().isStill()) {
                 pendingLiquidPositions.pollLast();
                 return;
@@ -229,20 +230,20 @@ public class PumpBlockEntity extends NetworkedBlockEntity implements FluidApi.Bl
         var blockBelow = stateBelow.getBlock();
         
         var isAirOrTrunk = stateBelow.isReplaceable() || blockBelow.equals(BlockContent.PUMP_TRUNK_BLOCK);
-        var isStillFluid = stateBelow.getFluidState().isStill();
+        var isFluid = !stateBelow.getFluidState().isEmpty();
         
-        return isStillFluid || !isAirOrTrunk;
+        return isFluid || !isAirOrTrunk;
     }
     
     private void startLiquidSearch(BlockPos start) {
         
         var state = world.getFluidState(start);
-        if (!state.isStill()) return;
+        if (state.isEmpty()) return;
         
         searchInstance = new FloodFillSearch(start, world);
         searchActive = true;
         
-        Oritech.LOGGER.debug("starting search at: " + start + " " + state.getFluid() + " " + state.isStill());
+        Oritech.LOGGER.debug("starting search at: " + start + " " + state.getFluid() + " " + !state.isEmpty());
     }
     
     private void finishSearch() {
@@ -328,7 +329,7 @@ public class PumpBlockEntity extends NetworkedBlockEntity implements FluidApi.Bl
         
         private boolean isValidTarget(BlockPos target) {
             var state = world.getFluidState(target);
-            return state.isStill();
+            return !state.isEmpty();
         }
         
         private void addNeighborsToQueue(BlockPos self) {

--- a/common/src/main/java/rearth/oritech/block/entity/reactor/NuclearExplosionEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/reactor/NuclearExplosionEntity.java
@@ -210,7 +210,7 @@ public class NuclearExplosionEntity extends BlockEntity implements BlockEntityTi
             var targetBlock = targetState.getBlock();
             var targetHardness = targetBlock.getBlastResistance();
 
-            if (targetBlock instanceof NuclearExplosionBlock || targetState.isAir() && !targetState.getFluidState().isStill() || targetState.getHardness(world, pos) < 0)
+            if (targetBlock instanceof NuclearExplosionBlock || targetState.isAir() || targetState.getHardness(world, pos) < 0)
                 continue;
 
             // skip too hard blocks (except for the first few)

--- a/common/src/main/java/rearth/oritech/item/tools/WeedKiller.java
+++ b/common/src/main/java/rearth/oritech/item/tools/WeedKiller.java
@@ -88,7 +88,7 @@ public class WeedKiller extends Item {
     
     private boolean isWeedBlock(BlockPos pos, World world) {
         var state = world.getBlockState(pos);
-        if (state.isAir() || state.getFluidState().isStill()) return false;
+        if (state.isAir() || !state.getFluidState().isEmpty()) return false;
         return state.isReplaceable() || state.isIn(BlockTags.FLOWERS);
     }
 }


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

Changes how the mod detects fluids by replacing most `FluidState.isStill()` calls with `!FluidState.isEmpty()`.

Currently, the mod does not treat flowing fluid blocks as fluids, leading to various issues, including:
- The Enderlic Laser keeps shooting at flowing fluids, while it should ignore them, just like still fluids.
- The Pump won't start extracting from a flowing fluid, despite being capable of searching and extrating the source blocks.
- The Destroyer Block attempts to break flowing fluids, while it should ignore them, just like still fluids. It slows down the quarry operations immensly, as water and lava have an unreasonably high hardness value of 100.
- The Block Hole can be easily nullified with water, as it gets stuck keep absorbing flowing water.

The one call in the `PumpBlockEntity::serverTick` was intentionally left unchanged to prevent infinite fluid generation, and a comment was added to clarify that.

# How Has This Been Tested?

I did a side by side testing to ensure the issues described above has been resolved.

- [x] Feature has been tested ingame on both neoforge and fabric.
- [x] Confirmed that the original issues have been resolved.

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas