### PR TITLE
QoL changes to small energy storage blocks

### DIFF
--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeBlock.java
@@ -208,7 +208,7 @@ public abstract class GenericPipeBlock extends AbstractPipeBlock implements Wren
     }
     
     @Override
-    public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand) {
+    public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, Direction face, PlayerEntity player, Hand hand) {
         if (player.isSneaking()) {
             this.onBreak(world, pos, state, player);
             world.breakBlock(pos, true, player);

--- a/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeDuctBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/pipes/GenericPipeDuctBlock.java
@@ -112,7 +112,7 @@ public abstract class GenericPipeDuctBlock extends AbstractPipeBlock implements 
 	}
 
 	@Override
-	public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand) {
+	public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, Direction face, PlayerEntity player, Hand hand) {
 		if (player.isSneaking()) {
 			world.breakBlock(pos, true, player);
 			return ActionResult.SUCCESS;

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/CreativeStorageBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/CreativeStorageBlock.java
@@ -18,12 +18,14 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.state.StateManager;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import rearth.oritech.block.entity.storage.CreativeStorageBlockEntity;
+import rearth.oritech.item.tools.Wrench;
 
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +33,7 @@ import java.util.Objects;
 import static rearth.oritech.block.blocks.storage.SmallStorageBlock.TARGET_DIR;
 import static rearth.oritech.util.TooltipHelper.addMachineTooltip;
 
-public class CreativeStorageBlock extends Block implements BlockEntityProvider {
+public class CreativeStorageBlock extends Block implements BlockEntityProvider, Wrench.Wrenchable {
     
     public CreativeStorageBlock(Settings settings) {
         super(settings);
@@ -81,7 +83,19 @@ public class CreativeStorageBlock extends Block implements BlockEntityProvider {
                 ticker.tick(world1, pos, state1, blockEntity);
         };
     }
-    
+
+    @Override
+    public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, Direction face, PlayerEntity player, Hand hand) {
+        var direction = state.get(TARGET_DIR) == face ? face.getOpposite() : face;
+        world.setBlockState(pos, state.with(TARGET_DIR, direction));
+        return ActionResult.SUCCESS;
+    }
+
+    @Override
+    public ActionResult onWrenchUseNeighbor(BlockState state, BlockState neighborState, World world, BlockPos pos, BlockPos neighborPos, Direction neighborFace, PlayerEntity player, Hand hand) {
+        return ActionResult.PASS;
+    }
+
     @Override
     public void appendTooltip(ItemStack stack, Item.TooltipContext context, List<Text> tooltip, TooltipType options) {
         super.appendTooltip(stack, context, tooltip, options);

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/CreativeStorageBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/CreativeStorageBlock.java
@@ -46,7 +46,9 @@ public class CreativeStorageBlock extends Block implements BlockEntityProvider {
     @Nullable
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
-        return Objects.requireNonNull(super.getPlacementState(ctx)).with(TARGET_DIR, ctx.getPlayerLookDirection().getOpposite());
+        var direction = ctx.getPlayerLookDirection().getOpposite();
+        if (ctx.getPlayer().isSneaking()) direction = direction.getOpposite();
+        return Objects.requireNonNull(super.getPlacementState(ctx)).with(TARGET_DIR, direction);
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
@@ -22,6 +22,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.DirectionProperty;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -33,6 +34,7 @@ import rearth.oritech.api.energy.EnergyApi;
 import rearth.oritech.block.base.entity.ExpandableEnergyStorageBlockEntity;
 import rearth.oritech.block.entity.storage.SmallStorageBlockEntity;
 import rearth.oritech.init.BlockContent;
+import rearth.oritech.item.tools.Wrench;
 import rearth.oritech.util.ComparatorOutputProvider;
 import rearth.oritech.util.MachineAddonController;
 
@@ -41,7 +43,7 @@ import java.util.Objects;
 
 import static rearth.oritech.util.TooltipHelper.addMachineTooltip;
 
-public class SmallStorageBlock extends Block implements BlockEntityProvider {
+public class SmallStorageBlock extends Block implements BlockEntityProvider, Wrench.Wrenchable {
     
     public static final DirectionProperty TARGET_DIR = DirectionProperty.of("target_dir");
     
@@ -184,7 +186,19 @@ public class SmallStorageBlock extends Block implements BlockEntityProvider {
         
         return super.onBreak(world, pos, state, player);
     }
-    
+
+    @Override
+    public ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, Direction face, PlayerEntity player, Hand hand) {
+        var direction = state.get(TARGET_DIR) == face ? face.getOpposite() : face;
+        world.setBlockState(pos, state.with(TARGET_DIR, direction));
+        return ActionResult.SUCCESS;
+    }
+
+    @Override
+    public ActionResult onWrenchUseNeighbor(BlockState state, BlockState neighborState, World world, BlockPos pos, BlockPos neighborPos, Direction neighborFace, PlayerEntity player, Hand hand) {
+        return ActionResult.PASS;
+    }
+
     @Override
     public void appendTooltip(ItemStack stack, Item.TooltipContext context, List<Text> tooltip, TooltipType options) {
         super.appendTooltip(stack, context, tooltip, options);

--- a/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
+++ b/common/src/main/java/rearth/oritech/block/blocks/storage/SmallStorageBlock.java
@@ -58,7 +58,9 @@ public class SmallStorageBlock extends Block implements BlockEntityProvider {
     @Nullable
     @Override
     public BlockState getPlacementState(ItemPlacementContext ctx) {
-        return Objects.requireNonNull(super.getPlacementState(ctx)).with(TARGET_DIR, ctx.getPlayerLookDirection().getOpposite());
+        var direction = ctx.getPlayerLookDirection().getOpposite();
+        if (ctx.getPlayer().isSneaking()) direction = direction.getOpposite();
+        return Objects.requireNonNull(super.getPlacementState(ctx)).with(TARGET_DIR, direction);
     }
     
     @Override

--- a/common/src/main/java/rearth/oritech/item/tools/Wrench.java
+++ b/common/src/main/java/rearth/oritech/item/tools/Wrench.java
@@ -79,19 +79,19 @@ public class Wrench extends Item {
         var world = player.getWorld();
         var result = raycast(world, player, RaycastContext.FluidHandling.NONE);
         if (result.getType() != HitResult.Type.BLOCK) return false;
-        
+
+        var direction = result.getSide();
         var blockPos = result.getBlockPos();
         var blockState = world.getBlockState(blockPos);
         if (blockState.getBlock() instanceof Wrenchable wrenchable) {
             // Wrench used on a wrenchable block
-            var resultAction = wrenchable.onWrenchUse(blockState, world, blockPos, player, hand);
+            var resultAction = wrenchable.onWrenchUse(blockState, world, blockPos, direction, player, hand);
             if (resultAction == ActionResult.SUCCESS) {
                 onUsed(item, player, hand);
                 return true;
             }
         } else {
             // Wrench used on block
-            var direction = result.getSide();
             var neighborPos = blockPos.offset(direction);
             var neighborState = world.getBlockState(neighborPos);
             
@@ -126,10 +126,11 @@ public class Wrench extends Item {
          * @param state  the block state
          * @param world  the world
          * @param pos    the block position
+         * @param face   the face of the block that was clicked
          * @param player the player using the wrench
          * @return the result of the wrench use
          */
-        ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand);
+        ActionResult onWrenchUse(BlockState state, World world, BlockPos pos, Direction face, PlayerEntity player, Hand hand);
         
         /**
          * Called when a wrench is used on a neighbor block


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

Some changes to the Portable Energy Storage and Creative Energy Storage to improve user experience.

- Sneaking now inverts their placement direction.
- They are now wrenchable to change their target (output) direction.
  - Using the wrench sets their target direction to the face that was clicked.
  - If the block is already facing the same way as the clicked face, it inverts the direction instead.

# How Has This Been Tested?

I checked the in-game behaviour of both the Portable Energy Storage and Creative Energy Storage to make sure everything is working as intended.

- [x] Feature has been tested ingame on both neoforge and fabric.

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas