### PR TITLE
Fix: Restrict soul collection to LivingEntity deaths only

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/arcane/BaseSoulCollectionEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/arcane/BaseSoulCollectionEntity.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -13,6 +14,7 @@ import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.gameevent.GameEventListener;
 import net.minecraft.world.level.gameevent.PositionSource;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class BaseSoulCollectionEntity extends BlockEntity implements GameEventListener.Provider<BaseSoulCollectionEntity.DeathListener> {
     
@@ -66,13 +68,18 @@ public abstract class BaseSoulCollectionEntity extends BlockEntity implements Ga
         
         @Override
         public boolean handleGameEvent(ServerLevel world, Holder<GameEvent> event, GameEvent.Context emitter, Vec3 emitterPos) {
-            if (event.is(GameEvent.ENTITY_DIE.key()) && emitter.sourceEntity() instanceof LivingEntity && canAcceptSoul() && !consumedEvents.contains(emitterPos)) {
+            if (event.is(GameEvent.ENTITY_DIE.key()) && isValidEntity(emitter.sourceEntity()) && canAcceptSoul() && !consumedEvents.contains(emitterPos)) {
                 onSoulIncoming(emitterPos);
                 consumedEvents.add(emitterPos);
                 return true;
             }
             
             return false;
+        }
+
+        private boolean isValidEntity(@Nullable Entity entity) {
+            // We allow null entities as the Soul Flower triggers a ENTITY_DIE game event with a null entity
+            return entity == null || entity instanceof LivingEntity;
         }
     }
 }

--- a/common/src/main/java/rearth/oritech/block/entity/arcane/BaseSoulCollectionEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/arcane/BaseSoulCollectionEntity.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -65,7 +66,7 @@ public abstract class BaseSoulCollectionEntity extends BlockEntity implements Ga
         
         @Override
         public boolean handleGameEvent(ServerLevel world, Holder<GameEvent> event, GameEvent.Context emitter, Vec3 emitterPos) {
-            if (event.is(GameEvent.ENTITY_DIE.key()) && canAcceptSoul() && !consumedEvents.contains(emitterPos)) {
+            if (event.is(GameEvent.ENTITY_DIE.key()) && emitter.sourceEntity() instanceof LivingEntity && canAcceptSoul() && !consumedEvents.contains(emitterPos)) {
                 onSoulIncoming(emitterPos);
                 consumedEvents.add(emitterPos);
                 return true;


### PR DESCRIPTION

# Description

Currently, all entities release souls after death. This means that entities like Boats, Paintings, Armor Stands and such can be used for soul collection, which seems wrong. 
This pr fixes this by making sure the entity extends LivingEntity.

Fixes #563 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. All changes have to be tested ingame on both loaders, and if any client-side code is involved, also on
a dedicated server to avoid any issues there.

- [x] Feature has been tested ingame on both neoforge and fabric.

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas