### PR TITLE
add nodules to the config file

### DIFF
--- a/common/src/main/java/rearth/oritech/init/Config.java
+++ b/common/src/main/java/rearth/oritech/init/Config.java
@@ -74,6 +74,7 @@ public class Config {
     @SectionHeader("worldGeneration")
     public boolean generateOresFabricOnly = true;
     public boolean easyFindFeatures = true;
+    public boolean generateResourceNodes = true;
     
     @SectionHeader("reactor")
     public boolean safeMode = false;

--- a/common/src/main/java/rearth/oritech/init/world/FeatureContent.java
+++ b/common/src/main/java/rearth/oritech/init/world/FeatureContent.java
@@ -39,23 +39,26 @@ public class FeatureContent implements ArchitecturyRegistryContainer<Feature<?>>
             }
         });
         
-        BiomeModifications.addProperties((context, mutable) -> {
-            if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
-                mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_common")));
-            }
-        });
-        
-        BiomeModifications.addProperties((context, mutable) -> {
-            if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
-                mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_rare")));
-            }
-        });
-        
-        BiomeModifications.addProperties((context, mutable) -> {
-            if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
-                mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_other")));
-            }
-        });
+        // resource nodes - only add if enabled in config
+        if (Oritech.CONFIG.generateResourceNodes()) {
+            BiomeModifications.addProperties((context, mutable) -> {
+                if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
+                    mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_common")));
+                }
+            });
+            
+            BiomeModifications.addProperties((context, mutable) -> {
+                if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
+                    mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_rare")));
+                }
+            });
+            
+            BiomeModifications.addProperties((context, mutable) -> {
+                if (context.hasTag(BiomeTags.IS_OVERWORLD)) {
+                    mutable.getGenerationProperties().addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, ResourceKey.create(Registries.PLACED_FEATURE, Oritech.id("resource_node_other")));
+                }
+            });
+        }
         
         // ores
         if (Oritech.CONFIG.generateOresFabricOnly()) {

--- a/common/src/main/java/rearth/oritech/init/world/features/resourcenode/ResourceNodeFeature.java
+++ b/common/src/main/java/rearth/oritech/init/world/features/resourcenode/ResourceNodeFeature.java
@@ -25,6 +25,11 @@ public class ResourceNodeFeature extends Feature<ResourceNodeFeatureConfig> {
     @Override
     public boolean place(FeaturePlaceContext<ResourceNodeFeatureConfig> context) {
 
+        // Check config to see if resource node generation is enabled
+        if (!Oritech.CONFIG.generateResourceNodes()) {
+            return false;
+        }
+
         var world = context.level();
         var origin = context.origin();
         


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description
This pull request aim to add an option in the config file to able/disable the ore nodes that spawn on the surface of the map.
For the context, I'm one of the dev in my friend's modded server and we wanted to add Oritech in the new version but nodes was considered as to easy to farm by the comunity so I wanted to disable this feature to be able to use the orithech.

<!--- Remove this if not applicable: -->
Fixes # (issue)

# How Has This Been Tested?

The changed have been tested on client and server side I havn't seen any issue while launching the game and generating the map with true/false in the config.

IMPORTATNT it have been tested only for neoforge

- [no] Feature has been tested ingame on both neoforge and fabric.

# Checklist:

- [no] My code uses the 'var' keyword where applicable.
- [yes] I have commented my code, particularly in hard-to-understand areas ( but in fact there is not that much complex part )



Additionaly, I would like to thank you for the mod it is really top tiers !