### PR TITLE
Remove @Debug annotation from ElytraLayerMixin

### DIFF
--- a/fabric/src/main/java/rearth/oritech/fabric/mixin/ElytraLayerMixin.java
+++ b/fabric/src/main/java/rearth/oritech/fabric/mixin/ElytraLayerMixin.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import rearth.oritech.item.tools.armor.JetpackElytraItem;
 import rearth.oritech.item.tools.armor.JetpackExoElytraItem;
-@Debug(export = true)
+
 @Mixin(value = ElytraLayer.class)
 public class ElytraLayerMixin {
 


### PR DESCRIPTION


<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description
Removed the `@Debug` annotation from ElytraLayerMixin.

I forgot to do this as a part of #556. The annotation is mostly harmless, it just causes mixin to write a class file to the .mixin.out folder when the elytra layer class is loaded.