### PR TITLE
fix typo in docs

### DIFF
--- a/docs/processing/reactor/components.mdx
+++ b/docs/processing/reactor/components.mdx
@@ -5,7 +5,7 @@ icon: oritech:area/reactor
 
 The reactor can be made from multiple different components:
 
-- **Reactor Controller**: The heat of your reactor. This block needs to be placed once somewhere on the walls. It needs to be interacted with to assemble / update the reactor.
+- **Reactor Controller**: The heart of your reactor. This block needs to be placed once somewhere on the walls. It needs to be interacted with to assemble / update the reactor.
 The GUI shows the current status of the reactor, along with the temperatures of the components and statistics. The GUI only shows the first layer of the interior.
 
 - **Reactor Wall**: The reactor wall is a very strong and highly blast-resistant piece of the reactor. It should encase the entire frame.


### PR DESCRIPTION
# Description

I found what I believe to be a typo in the Reactor docs.

# How Has This Been Tested?

I have checked the relevant doc inside of Oracle Index. This change is visible ingame.

- [x] Feature has been tested ingame on both neoforge and fabric.
- [ ] Optional additional testing details

# Checklist:

- [ ] My code uses the 'var' keyword where applicable.
- [ ] I have commented my code, particularly in hard-to-understand areas