### PR TITLE
Use slot-by-slot insertion to resolve Fluid Tank transfer issue with Item Pipes

### DIFF
--- a/fabric/src/main/java/rearth/oritech/fabric/FabricItemApi.java
+++ b/fabric/src/main/java/rearth/oritech/fabric/FabricItemApi.java
@@ -69,6 +69,36 @@ public class FabricItemApi implements BlockItemApi {
         @Override
         public int insert(ItemStack inserted, boolean simulate) {
             if (inserted.isEmpty()) return 0;
+
+            // Use slot-by-slot insertion to respect item max stack size,
+            // which Fabric's bulk insert may not check for component-based MAX_STACK_SIZE
+            if (storage instanceof SlottedStorage<ItemVariant> slottedStorage) {
+                var variant = ItemVariant.of(inserted);
+                var maxStackSize = inserted.getMaxStackSize();
+                var remaining = inserted.getCount();
+
+                try (var transaction = Transaction.openOuter()) {
+                    for (int i = 0; i < slottedStorage.getSlotCount() && remaining > 0; i++) {
+                        var slot = slottedStorage.getSlot(i);
+                        var currentAmount = (int) slot.getAmount();
+
+                        // Skip slots that are full according to the item's max stack size
+                        if (!slot.isResourceBlank() && currentAmount >= maxStackSize) continue;
+
+                        var canInsert = Math.min(remaining, maxStackSize - (slot.isResourceBlank() ? 0 : currentAmount));
+                        if (canInsert <= 0) continue;
+
+                        var insertedCount = (int) slot.insert(variant, canInsert, transaction);
+                        remaining -= insertedCount;
+                    }
+
+                    if (!simulate)
+                        transaction.commit();
+                    return inserted.getCount() - remaining;
+                }
+            }
+
+            // Fallback for non-slotted storage
             try (var transaction = Transaction.openOuter()) {
                 var insertCount = storage.insert(ItemVariant.of(inserted), inserted.getCount(), transaction);
                 if (!simulate)


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

This PR attempts to address #705 

As described in the issue, when multiple filled Portable Tanks (or Portable tanks with duplicate fullness values) are transferred into an inventory via an Item Pipe, the source chest will receive only one of the Portable Tanks, with the subsequently transferred Portable Tanks disappearing. 

It looks like Fabric's `Storage.insert()` method does not respect the item's `DataComponents.MAX_STACK_SIZE` when merging into existing slots in vanilla inventories. This may imply that the problem exists for other items as well, though I did not find any other cases during testing. 

The fix adds a slot-by-slot transfer for `SlottedStorage` inventories in the `FabricItemApi` wrapper class, to ensure that the inserted item's `MaxStackSize` is respected. For non `SlottedStorage` inventories, the original behavior is preserved. 

**Full transparency: I used Claude Code to help make this PR.**

Further disclaimer: I know very little about Minecraft mod dev - so I am not sure that this is the correct approach to the bugfix or if this approach might carry other implications. 



Fixes #705 

# How Has This Been Tested?

This was tested in game on a fresh instance of Minecraft 1.21.1 with only the Fabric loader and Oritech 1.0.1 installed. I used the same test setup as described in #705 - two chests next to each other, with a source chest being extracted to the target chest. I filled several tanks of both Turbofuel and Sulfuric Acid and verified that the target chest received each tank as expected. 

It is worth noting that this problem is not specific to Portable Tanks, but rather seems to be an issue in any case where an item uses DataComponents.MAX_STACK_SIZE to change from the default stack size. I also tested the fix with some diamonds given via `/give @s diamond[max_stack_size=1]`, which reproduced the problem behavior in an unmodified Oritech install, and which also behaves appropriately after applying this PR. 