### PR TITLE
Call setPlacedBy with the Placer Block's Player to transfer components when placing blocks

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/interaction/PlacerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/interaction/PlacerBlockEntity.java
@@ -79,6 +79,7 @@ public class PlacerBlockEntity extends ItemEnergyFrameInteractionBlockEntity imp
         
         if (Objects.requireNonNull(level).getBlockState(targetPosition).isAir() && placementState != null && placementState.canSurvive(level, targetPosition)) {
             level.setBlockAndUpdate(targetPosition, placementState);
+            block.setPlacedBy(level, targetPosition, placementState, getPlacerPlayerEntity(), firstBlock);
             firstBlock.shrink(1);
             level.playSound(null, targetPosition, placementState.getSoundType().getPlaceSound(), SoundSource.BLOCKS, 1f, 1f);
             super.finishBlockWork(processed);


### PR DESCRIPTION
# Description

This PR adds a call to setPlacedBy, using the Placer Block's Player entity, when the Placer machine places a block. 

This ensures that placed blocks, like Portable Tanks, utilize their internal logic for copying custom components (like Fluid count) when placed by the Placer block.


Fixes #707

# How Has This Been Tested?

Tested in both Neoforge 21.2.219 and Fabric 0.18.4, using the same apparatus used to produce the bug described in #707 . 

With the fix in place, when a filled portable tank is placed by the Placer Block, the tank is placed with the appropriate amount of fluid, as a player might intuitively expect. 


