### PR TITLE
Fix RF generation rates in Japanese documentation

### DIFF
--- a/docs/.translated/ja_jp/processing/generators.mdx
+++ b/docs/.translated/ja_jp/processing/generators.mdx
@@ -12,7 +12,7 @@ Oritechシステムにおいて、発電機は他のすべての機械やツー�
 <ModAsset location="oritech:basic_generator_block" width={256} />
 </center>
 
-基本の発電機は燃料を燃焼させる仕組みで動作します（炉と同様の原理）。この発電機は**1時間あたり32 RF**を生成します。
+基本の発電機は燃料を燃焼させる仕組みで動作します（炉と同様の原理）。この発電機は**32 RF/t**で発電します。
 
 ---
 
@@ -20,7 +20,7 @@ Oritechシステムにおいて、発電機は他のすべての機械やツー�
 <ModAsset location="oritech:lava_generator_block" width={512} />
 </center>
 
-溶岩発電機は[流体パイプ](../logistics/fluid_transport)で供給される溶岩を燃焼させます。2つの[アドオンスロット](../processing/addons)を備えており、**1時間あたり64 RF**を生成します。
+溶岩発電機は[流体パイプ](../logistics/fluid_transport)で供給される溶岩を燃焼させます。2つの[アドオンスロット](../processing/addons)を備えており、**64 RF/t**で発電します。
 
 ---
 
@@ -28,7 +28,7 @@ Oritechシステムにおいて、発電機は他のすべての機械やツー�
 <ModAsset location="oritech:bio_generator_block" width={512} />
 </center>
 
-バイオ発電機はバイオマスを燃料として燃焼させます。こちらも2つの[アドオンスロット](../processing/addons)を備えており、**1時間あたり64 RF**を生成します。
+バイオ発電機はバイオマスを燃料として燃焼させます。こちらも2つの[アドオンスロット](../processing/addons)を備えており、**64RF/t**で発電します。
 
 ---
 
@@ -36,7 +36,7 @@ Oritechシステムにおいて、発電機は他のすべての機械やツー�
 <ModAsset location="oritech:big_solar_panel_block" width={512} />
 </center>
 
-大型ソーラーパネルは、マルチブロックに使用する[マシンコア](../processing/multiblocks)に応じて、**1時間あたり32 RF**から**224 RF**までの範囲で発電可能です。モデルは太陽の動きに合わせて自動的に追従します。動作するのは昼間のみです。
+大型ソーラーパネルは、マルチブロックに使用する[マシンコア](../processing/multiblocks)に応じて、***32~224 RF/t**で発電します。までの範囲で発電可能です。モデルは太陽の動きに合わせて自動的に追従します。動作するのは昼間のみです。
 
 ---
 
@@ -44,7 +44,7 @@ Oritechシステムにおいて、発電機は他のすべての機械やツー�
 <ModAsset location="oritech:fuel_generator_block" width={512} />
 </center>
 
-燃料発電機は[原油](../resources/crude_oil)またはターボ燃料を燃焼させます。2つの[アドオンスロット](../processing/addons)を備えており、**1時間あたり256 RF**を生成します。
+燃料発電機は[原油](../resources/crude_oil)またはターボ燃料を燃焼させます。2つの[アドオンスロット](../processing/addons)を備えており、**256 RF/t**で発電します。
 
 ---
 


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description
"64 RF/t" was translated as "64 RF/hour" in Japanese.

Therefore, the phrase "1時間あたり64 RF" was corrected by replacing it with "64 RF/t".

Furthermore, all translations containing this incorrect translation have been corrected.

# How Has This Been Tested?
I tested this by extracting oritech.jar and replacing the file in the "oritech/assets/oracle_index/books/oritech/.translated/ja_jp/processing/generators.mdx" section.
I confirmed that the changes were reflected on the client side.
<img width="635" height="276" alt="Screenshot from 2026-04-08 04-13-48" src="https://github.com/user-attachments/assets/069afbb4-7e50-44a2-8dd4-c323f72eabb2" />

- [x] Feature has been tested ingame on both neoforge and fabric.
- [ ] Optional additional testing details

# Checklist:

- [ ] My code uses the 'var' keyword where applicable.
- [ ] I have commented my code, particularly in hard-to-understand areas