### PR TITLE
Large particle accelerator performance optimization

### DIFF
--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorControllerBlockEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorControllerBlockEntity.java
@@ -89,7 +89,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
         
         if (particle != null && activeItemParticle != null && activeItemParticle != ItemStack.EMPTY) {
             var data = new CompoundTag();
-            data.putFloat("speed", particle.velocity);
+            data.putLong("speed", particle.velocity);
             data.putFloat("posX", (float) particle.position.x);
             data.putFloat("posY", (float) particle.position.y);
             data.putFloat("posZ", (float) particle.position.z);
@@ -109,7 +109,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
         
         if (nbt.contains("particle")) {
             var data = nbt.getCompound("particle");
-            var speed = data.getFloat("speed");
+            var speed = data.getLong("speed");
             var posX = data.getFloat("posX");
             var posY = data.getFloat("posY");
             var posZ = data.getFloat("posZ");
@@ -163,7 +163,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
         this.setChanged();
     }
     
-    public void onParticleCollided(float relativeSpeed, Vec3 collision, AcceleratorControllerBlockEntity secondControllerEntity) {
+    public void onParticleCollided(long relativeSpeed, Vec3 collision, AcceleratorControllerBlockEntity secondControllerEntity) {
         
         // create end portal area when two ender pearls collide, nether portal for two firecharges
         if (relativeSpeed > OritechConfig.endPortalRequiredSpeed.get() && activeItemParticle.getItem().equals(Items.ENDER_PEARL) && secondControllerEntity.activeItemParticle.getItem().equals(Items.ENDER_PEARL)) {
@@ -219,7 +219,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
     
     }
     
-    private boolean tryCraftResult(float speed, ItemStack inputA, ItemStack inputB) {
+    private boolean tryCraftResult(long speed, ItemStack inputA, ItemStack inputB) {
         
         if (inputA == null || inputA.isEmpty() || inputB == null || inputB.isEmpty()) return false;
         
@@ -349,7 +349,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
     }
     
     // returns the amount of moment used
-    public float handleParticleEntityCollision(BlockPos checkPos, AcceleratorParticleLogic.ActiveParticle particle, float remainingMomentum, LivingEntity mob) {
+    public float handleParticleEntityCollision(BlockPos checkPos, AcceleratorParticleLogic.ActiveParticle particle, long remainingMomentum, LivingEntity mob) {
         
         var maxApplicableDamage = mob.getHealth();
         var inflictedDamage = Math.min(remainingMomentum, maxApplicableDamage);
@@ -361,7 +361,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
         return inflictedDamage;
     }
     
-    public float handleParticleBlockCollision(BlockPos checkPos, AcceleratorParticleLogic.ActiveParticle particle, float remainingMomentum, BlockState hitState) {
+    public float handleParticleBlockCollision(BlockPos checkPos, AcceleratorParticleLogic.ActiveParticle particle, long remainingMomentum, BlockState hitState) {
         
         var blockHardness = hitState.getDestroySpeed(level, checkPos);
         
@@ -520,7 +520,7 @@ public class AcceleratorControllerBlockEntity extends BlockEntity implements Blo
     public record LastEventPacket(BlockPos position,
                                   ParticleEvent lastEvent,
 // for no gate found events, we can calculate the acceptable dist based on speed
-                                  float lastEventSpeed,
+                                  long lastEventSpeed,
 // this is particle speed usually, and collision speed for collisions
                                   BlockPos lastEventPosition,  // where it collided/exited
                                   float minBendDist,   // acceptable dist can be calculated from dist

--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
@@ -5,6 +5,7 @@ import net.minecraft.core.Vec3i;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -26,6 +27,7 @@ public class AcceleratorParticleLogic {
     private final AcceleratorControllerBlockEntity entity;
     
     private static final Map<CompPair<BlockPos, Vec3i>, BlockPos> cachedGates = new HashMap<>();    // stores the next gate for a combo of source gate and direction
+    private static final Map<BlockPos, BlockState> cachedGateStates = new HashMap<>(); // caches the block states where gates are to not have to call world.getBlockState 1 billion times per tick
     private static final Map<BlockPos, BlockPos> activeParticles = new HashMap<>(); // stores relations between position of particle -> position of controller
     
     public AcceleratorParticleLogic(BlockPos pos, ServerLevel world, AcceleratorControllerBlockEntity entity) {
@@ -122,7 +124,7 @@ public class AcceleratorParticleLogic {
                 }
                 
                 // handle gate interaction (e.g. motor or sensor)
-                var gateBlock = world.getBlockState(reachedGate).getBlock();
+                var gateBlock = getCachedGate(reachedGate).getBlock();
                 if (gateBlock.equals(BlockContent.ACCELERATOR_MOTOR)) {
                     entity.handleParticleMotorInteraction(reachedGate);
                 } else if (gateBlock.equals(BlockContent.ACCELERATOR_SENSOR) && world.getBlockEntity(reachedGate) instanceof AcceleratorSensorBlockEntity sensorEntity) {
@@ -140,6 +142,16 @@ public class AcceleratorParticleLogic {
         }
         
         entity.onParticleMoved(renderedTrail);
+    }
+
+    private BlockState getCachedGate(BlockPos pos)
+    {
+        BlockState state = cachedGateStates.get(pos);
+        if (state != null)
+            return state;
+        state = world.getBlockState(pos);
+        cachedGateStates.put(pos, state);
+        return state;
     }
     
     private void calculateCollision(ActiveParticle particle, ArrayList<BlockPos> foundCollisions, Pair<ActiveParticle, AcceleratorControllerBlockEntity> collidedWith) {
@@ -250,7 +262,7 @@ public class AcceleratorParticleLogic {
         var incomingStraight = incomingPath.getX() == 0 || incomingPath.getZ() == 0;
         var incomingDir = new Vec3i(Math.clamp(incomingPath.getX(), -1, 1), 0, Math.clamp(incomingPath.getZ(), -1, 1));
         
-        var targetState = world.getBlockState(nextGate);
+        var targetState = getCachedGate(nextGate);
         var targetBlock = targetState.getBlock();
         
         // go straight through motors and sensors
@@ -384,11 +396,17 @@ public class AcceleratorParticleLogic {
     public static void resetCachedGate(BlockPos pos) {
         var toRemove = cachedGates.entrySet().stream().filter(elem -> elem.getKey().getA().equals(pos) || elem.getValue().equals(pos)).map(Map.Entry::getKey).toList();
         toRemove.forEach(cachedGates::remove);
+
+        var toRemove2 = cachedGateStates.entrySet().stream().filter(elem -> elem.getKey().equals(pos)).toList();
+        toRemove2.forEach(cachedGateStates::remove);
     }
     
     public static void resetNearbyCache(BlockPos pos) {
         var toRemove = cachedGates.keySet().stream().filter(blockPos -> blockPos.getA().distManhattan(pos) < OritechConfig.maxGateDist.get() + 1).toList();
         toRemove.forEach(cachedGates::remove);
+
+        var toRemove2 = cachedGateStates.keySet().stream().filter(blockPos -> blockPos.distManhattan(pos) < OritechConfig.maxGateDist.get() + 1).toList();
+        toRemove2.forEach(cachedGateStates::remove);
     }
     
     public static final class CompPair<A, B> extends Tuple<A, B> {
@@ -414,13 +432,13 @@ public class AcceleratorParticleLogic {
     
     public static final class ActiveParticle {
         public Vec3 position;
-        public float velocity;
+        public long velocity;
         public BlockPos nextGate;
         public BlockPos lastGate;
         public float lastBendDistance = 15000;
         public float lastBendDistance2 = 15000;
         
-        public ActiveParticle(Vec3 position, float velocity, BlockPos nextGate, BlockPos lastGate) {
+        public ActiveParticle(Vec3 position, long velocity, BlockPos nextGate, BlockPos lastGate) {
             this.position = position;
             this.velocity = velocity;
             this.nextGate = nextGate;

--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
@@ -146,7 +146,7 @@ public class AcceleratorParticleLogic {
 
     private BlockState getCachedGate(BlockPos pos)
     {
-        BlockState state = cachedGateStates.get(pos);
+        var state = cachedGateStates.get(pos);
         if (state != null)
             return state;
         state = world.getBlockState(pos);

--- a/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
+++ b/common/src/main/java/rearth/oritech/block/entity/accelerator/AcceleratorParticleLogic.java
@@ -146,6 +146,7 @@ public class AcceleratorParticleLogic {
 
     private BlockState getCachedGate(BlockPos pos)
     {
+        // tries to get a block state that was cached, if possible
         var state = cachedGateStates.get(pos);
         if (state != null)
             return state;


### PR DESCRIPTION
# Description

I added extra caching for the particle accelerators.
This was done because I wanted to be able to reach over 1% of light speed.
This needs a particle accelerator that has very long sections (7km for light speed), causing lag at high speeds as the particle checks blocks in unloaded chunks and thus loads them as it is going through them at a rate of hundreds of chunks per second.
So I simply cached the result of the block state queries and it ran much smoother. However, there is still lag at extremely high velocities.

The second change I did was changing the particle speed type from float to long since it never uses decimal values, as far as I could tell, and floats can get stuck at certain numbers when just adding one.
It can now accelerate up to at least 10% of light speed.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. All changes have to be tested ingame on both loaders, and if any client-side code is involved, also on
a dedicated server to avoid any issues there.

- [x] Feature has been tested ingame on both neoforge and fabric.
- [x] Was tested in a survival world I have been playing in and did not notice any problems.

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas