### PR TITLE
Updating git actions for 26.1.2 (and updating deprecating action versions)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: setup jdk 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'microsoft'
       - name: setup gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
         with:
           cache-overwrite-existing: true
       - name: make gradle wrapper executable
@@ -51,6 +51,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts
-          path: |
-            fabric/build/libs/
-            neoforge/build/libs/
+          path: build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: build
         run: ./gradlew build --stacktrace
       - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           path: build/libs


### PR DESCRIPTION
# Description

Update git actions to use non-deprecated actions versions and to capture the build/libs output (instead of fabric/build/libs and neoforge/build/libs)

# How Has This Been Tested?

It hasn't yet, but hopefully opening the PR will test it :)

- [N/A] Feature has been tested ingame on both neoforge and fabric.
- [N/A] Optional additional testing details

# Checklist:

- [N/A] My code uses the 'var' keyword where applicable.
- [N/A] I have commented my code, particularly in hard-to-understand areas