### PR TITLE
Optimize energy pipe network distribution

### DIFF
--- a/common/src/main/java/rearth/oritech/Oritech.java
+++ b/common/src/main/java/rearth/oritech/Oritech.java
@@ -23,6 +23,7 @@ import rearth.oritech.block.entity.augmenter.PlayerAugments;
 import rearth.oritech.block.entity.augmenter.api.Augment;
 import rearth.oritech.block.entity.interaction.PowerPoleEntity;
 import rearth.oritech.block.entity.pipes.GenericPipeInterfaceEntity;
+import rearth.oritech.block.entity.pipes.EnergyPipeInterfaceEntity;
 import rearth.oritech.client.init.ModScreens;
 import rearth.oritech.client.init.ParticleContent;
 import rearth.oritech.init.*;
@@ -59,6 +60,7 @@ public final class Oritech {
         
         // for pipe data
         LifecycleEvent.SERVER_STARTED.register(Oritech::onServerStarted);
+        LifecycleEvent.SERVER_STOPPED.register(server -> EnergyPipeInterfaceEntity.clearRuntimeData());
         
         // for augment data
         LifecycleEvent.SERVER_STARTED.register(server -> PlayerAugments.loadAllAugments(server.getRecipeManager()));

--- a/common/src/main/java/rearth/oritech/api/energy/containers/AggregatingEnergyStorage.java
+++ b/common/src/main/java/rearth/oritech/api/energy/containers/AggregatingEnergyStorage.java
@@ -1,0 +1,115 @@
+package rearth.oritech.api.energy.containers;
+
+import rearth.oritech.api.energy.EnergyApi;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A read-only view over multiple energy storages.
+ *
+ * <p>Extraction is spread across the backing storages without moving their energy into an
+ * intermediate buffer. Each backing storage keeps its own extraction limit, so the aggregate's
+ * throughput is the sum of the throughput available from its members.</p>
+ */
+public class AggregatingEnergyStorage extends EnergyApi.EnergyStorage {
+
+    private final List<? extends EnergyApi.EnergyStorage> storages;
+    private final long[] remainingExtractable;
+    private final Set<EnergyApi.EnergyStorage> changedStorages = Collections.newSetFromMap(new IdentityHashMap<>());
+    private long amount;
+    private long extractableAmount;
+    private long capacity;
+    private int extractionIndex;
+
+    public AggregatingEnergyStorage(List<? extends EnergyApi.EnergyStorage> storages) {
+        this.storages = List.copyOf(storages);
+        this.remainingExtractable = new long[storages.size()];
+
+        for (var i = 0; i < storages.size(); i++) {
+            var storage = storages.get(i);
+            amount = saturatedAdd(amount, storage.getAmount());
+            capacity = saturatedAdd(capacity, storage.getCapacity());
+
+            if (!storage.supportsExtraction()) continue;
+            remainingExtractable[i] = storage.extract(Long.MAX_VALUE, true);
+            extractableAmount = saturatedAdd(extractableAmount, remainingExtractable[i]);
+        }
+    }
+
+    @Override
+    public boolean supportsInsertion() {
+        return false;
+    }
+
+    @Override
+    public long insert(long maxAmount, boolean simulate) {
+        return 0;
+    }
+
+    @Override
+    public long extract(long maxAmount, boolean simulate) {
+        if (maxAmount <= 0) return 0;
+        var requested = Math.min(maxAmount, extractableAmount);
+        if (simulate) return requested;
+
+        long extracted = 0;
+        while (extracted < requested && extractionIndex < storages.size()) {
+            var remainingFromStorage = remainingExtractable[extractionIndex];
+            if (remainingFromStorage <= 0) {
+                extractionIndex++;
+                continue;
+            }
+
+            var storage = storages.get(extractionIndex);
+            var toExtract = Math.min(requested - extracted, remainingFromStorage);
+            var extractedFromStorage = storage.extract(toExtract, false);
+            if (extractedFromStorage <= 0) {
+                remainingExtractable[extractionIndex] = 0;
+                extractionIndex++;
+                continue;
+            }
+
+            remainingExtractable[extractionIndex] -= extractedFromStorage;
+            extracted += extractedFromStorage;
+            amount -= extractedFromStorage;
+            extractableAmount -= extractedFromStorage;
+            changedStorages.add(storage);
+
+            if (extractedFromStorage < toExtract || remainingExtractable[extractionIndex] <= 0) {
+                remainingExtractable[extractionIndex] = 0;
+                extractionIndex++;
+            }
+        }
+
+        return extracted;
+    }
+
+    @Override
+    public void setAmount(long amount) {
+        throw new UnsupportedOperationException("Cannot set the amount of an aggregating energy storage");
+    }
+
+    @Override
+    public long getAmount() {
+        return amount;
+    }
+
+    @Override
+    public long getCapacity() {
+        return capacity;
+    }
+
+    @Override
+    public void update() {
+        changedStorages.forEach(EnergyApi.EnergyStorage::update);
+        changedStorages.clear();
+    }
+
+    private static long saturatedAdd(long first, long second) {
+        if (second > Long.MAX_VALUE - first) return Long.MAX_VALUE;
+        return first + second;
+    }
+}

--- a/common/src/main/java/rearth/oritech/block/entity/pipes/EnergyPipeInterfaceEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/pipes/EnergyPipeInterfaceEntity.java
@@ -1,17 +1,22 @@
 package rearth.oritech.block.entity.pipes;
 
 import rearth.oritech.init.OritechConfig;
-import rearth.oritech.Oritech;
 import rearth.oritech.api.energy.EnergyApi;
+import rearth.oritech.api.energy.containers.AggregatingEnergyStorage;
 import rearth.oritech.api.energy.containers.SimpleEnergyStorage;
 import rearth.oritech.block.blocks.pipes.energy.EnergyPipeBlock;
 import rearth.oritech.block.blocks.pipes.energy.SuperConductorBlock;
 import rearth.oritech.init.BlockContent;
 import rearth.oritech.init.BlockEntitiesContent;
+
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Set;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
@@ -20,12 +25,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class EnergyPipeInterfaceEntity extends GenericPipeInterfaceEntity implements EnergyApi.BlockProvider {
+
+    // PipeNetworkData is level-scoped but shared by every interface in that pipe type. Keeping the
+    // dispatcher here makes its per-tick state transient instead of adding it to saved topology.
+    private static final Map<PipeNetworkData, PipeDataRuntime> PIPE_DATA_RUNTIMES = new IdentityHashMap<>();
     
     private final SimpleEnergyStorage energyStorage;
     private final boolean isSuperConductor;
-    
-    private List<ExtractablePipeInterfaceEntity.CachedTarget<EnergyApi.EnergyStorage>> cachedTargets = new ArrayList<>();
-    private int cacheHash;
     
     public EnergyPipeInterfaceEntity(BlockPos pos, BlockState state) {
         super(BlockEntitiesContent.ENERGY_PIPE_ENTITY, pos, state);
@@ -59,43 +65,157 @@ public class EnergyPipeInterfaceEntity extends GenericPipeInterfaceEntity implem
     
     @Override
     public void tick(Level world, BlockPos pos, BlockState state, GenericPipeInterfaceEntity blockEntity) {
-        // if energy is available
-        // gather all connection targets supporting insertion
-        // shuffle em
-        // insert until no more energy is available
-        
-        if (world.isClientSide || energyStorage.getAmount() <= 0) return;
+        if (world.isClientSide) return;
         
         var dataSource = isSuperConductor ? SuperConductorBlock.SUPERCONDUCTOR_DATA : EnergyPipeBlock.ENERGY_PIPE_DATA;
-        
-        var data = dataSource.getOrDefault(world.dimension().location(), new PipeNetworkData());
-        var targets = findNetworkTargets(pos, data);
-        
-        if (targets == null) return;    // this should never happen
-        
-        var targetHash = targets.hashCode();
+        var data = dataSource.get(world.dimension().location());
+        if (data == null) return;
 
-        if (this.cacheHash != targetHash) {
-            this.cachedTargets = targets.stream()
-                                   .map(target -> new ExtractablePipeInterfaceEntity.CachedTarget<>(target.getA(), target.getB(), EnergyApi.BLOCK.createCache(world, target.getA(), target.getB())))
-                                   .collect(Collectors.toList());
-            this.cacheHash = targetHash;
-        }
-        
-        Collections.shuffle(this.cachedTargets);
-        
-        for (var cachedTarget : this.cachedTargets) {
-            if (energyStorage.getAmount() <= 0) break;
-            var targetStorage = cachedTarget.lookup().find();
-            if (targetStorage == null || !targetStorage.supportsInsertion()) continue;
-            EnergyApi.transfer(energyStorage, targetStorage, Long.MAX_VALUE, false);
-        }
-        
+        var pipeRuntime = PIPE_DATA_RUNTIMES.computeIfAbsent(data, ignored -> new PipeDataRuntime());
+        pipeRuntime.removeStaleNetworks(data);
+
+        if (energyStorage.getAmount() <= 0) return;
+
+        var networkId = data.pipeNetworkLinks.getOrDefault(pos, -1);
+        if (networkId == -1) return;
+
+        var networkRuntime = pipeRuntime.networks.computeIfAbsent(networkId, ignored -> new EnergyNetworkRuntime());
+        var gameTime = world.getGameTime();
+        if (networkRuntime.lastProcessedTick == gameTime) return;
+
+        // Every interface still ticks, but only the first energized interface dispatches for the
+        // whole network. This changes the hot path from N sources walking M targets to one O(N + M)
+        // pass while retaining the combined extraction limit of every source interface.
+        networkRuntime.lastProcessedTick = gameTime;
+        networkRuntime.rebuildIfNeeded(world, data, networkId);
+        networkRuntime.distribute(world, this);
+    }
+
+    public static void clearRuntimeData() {
+        PIPE_DATA_RUNTIMES.values().forEach(PipeDataRuntime::clear);
+        PIPE_DATA_RUNTIMES.clear();
     }
     
     @Override
     public void setChanged() {
         if (this.level != null)
             level.blockEntityChanged(worldPosition);
+    }
+
+    private static final class PipeDataRuntime {
+        private final Map<Integer, EnergyNetworkRuntime> networks = new HashMap<>();
+        private long topologyRevision = Long.MIN_VALUE;
+
+        private void removeStaleNetworks(PipeNetworkData data) {
+            if (topologyRevision == data.getTopologyRevision()) return;
+
+            var iterator = networks.entrySet().iterator();
+            while (iterator.hasNext()) {
+                var entry = iterator.next();
+                var networkId = entry.getKey();
+                var network = entry.getValue();
+
+                if (!data.pipeNetworks.containsKey(networkId)) {
+                    network.invalidateTopology();
+                    iterator.remove();
+                } else if (network.topologyRevision != data.getNetworkRevision(networkId)) {
+                    network.invalidateTopology();
+                }
+            }
+            topologyRevision = data.getTopologyRevision();
+        }
+
+        private void clear() {
+            networks.values().forEach(EnergyNetworkRuntime::invalidateTopology);
+            networks.clear();
+        }
+    }
+
+    private static final class EnergyNetworkRuntime {
+        private long topologyRevision = Long.MIN_VALUE;
+        private long lastProcessedTick = Long.MIN_VALUE;
+        private int nextSourceIndex;
+        private int nextTargetIndex;
+        private List<BlockPos> sourcePositions = List.of();
+        private List<ExtractablePipeInterfaceEntity.CachedTarget<EnergyApi.EnergyStorage>> targets = List.of();
+
+        private void invalidateTopology() {
+            targets.forEach(target -> target.lookup().invalidate());
+            targets = List.of();
+            sourcePositions = List.of();
+            topologyRevision = Long.MIN_VALUE;
+        }
+
+        private void rebuildIfNeeded(Level world, PipeNetworkData data, int networkId) {
+            var currentRevision = data.getNetworkRevision(networkId);
+            if (topologyRevision == currentRevision) return;
+
+            sourcePositions = data.pipeNetworks.getOrDefault(networkId, Set.of()).stream()
+                                .filter(data.machineInterfaces::containsKey)
+                                .sorted(Comparator.comparingLong(BlockPos::asLong))
+                                .toList();
+            var sourcePositionSet = new HashSet<>(sourcePositions);
+
+            targets = data.pipeNetworkInterfaces.getOrDefault(networkId, Set.of()).stream()
+                          // A stale/corrupt topology entry must never feed an interface buffer back
+                          // into the same network and create an energy ping-pong loop.
+                          .filter(target -> !sourcePositionSet.contains(target.getA()))
+                          .sorted(Comparator.comparingLong((net.minecraft.util.Tuple<BlockPos, Direction> target) -> target.getA().asLong())
+                                            .thenComparingInt(target -> target.getB().ordinal()))
+                          .map(target -> new ExtractablePipeInterfaceEntity.CachedTarget<>(
+                              target.getA(), target.getB(), EnergyApi.BLOCK.createCache(world, target.getA(), target.getB())))
+                          .toList();
+
+            if (targets.isEmpty()) nextTargetIndex = 0;
+            else nextTargetIndex = Math.floorMod(nextTargetIndex, targets.size());
+            if (sourcePositions.isEmpty()) nextSourceIndex = 0;
+            else nextSourceIndex = Math.floorMod(nextSourceIndex, sourcePositions.size());
+            topologyRevision = currentRevision;
+        }
+
+        private void distribute(Level world, EnergyPipeInterfaceEntity triggeringInterface) {
+            var sources = new ArrayList<EnergyApi.EnergyStorage>(sourcePositions.size());
+            var includedTrigger = false;
+            var sourceCount = sourcePositions.size();
+            var sourceStartIndex = sourceCount == 0 ? 0 : Math.floorMod(nextSourceIndex, sourceCount);
+
+            for (var offset = 0; offset < sourceCount; offset++) {
+                var sourcePos = sourcePositions.get((sourceStartIndex + offset) % sourceCount);
+                if (!world.hasChunkAt(sourcePos)) continue;
+
+                var sourceEntity = world.getBlockEntity(sourcePos);
+                if (!(sourceEntity instanceof EnergyPipeInterfaceEntity source) || source.isRemoved()) continue;
+                if (source.isSuperConductor != triggeringInterface.isSuperConductor) continue;
+
+                if (source == triggeringInterface) includedTrigger = true;
+                if (source.energyStorage.getAmount() > 0) sources.add(source.energyStorage);
+            }
+
+            if (sourceCount > 0) nextSourceIndex = (sourceStartIndex + 1) % sourceCount;
+
+            // Be defensive against topology data that is still being repaired during block updates.
+            // The triggering interface is known to belong to this network and must not be stranded.
+            if (!includedTrigger && triggeringInterface.energyStorage.getAmount() > 0) {
+                sources.add(triggeringInterface.energyStorage);
+            }
+
+            if (sources.isEmpty() || targets.isEmpty()) return;
+
+            var aggregate = new AggregatingEnergyStorage(sources);
+            var targetCount = targets.size();
+            var startIndex = Math.floorMod(nextTargetIndex, targetCount);
+
+            for (var offset = 0; offset < targetCount && aggregate.extract(Long.MAX_VALUE, true) > 0; offset++) {
+                var target = targets.get((startIndex + offset) % targetCount);
+                var targetStorage = target.lookup().find();
+                if (targetStorage == null || !targetStorage.supportsInsertion()) continue;
+
+                EnergyApi.transfer(aggregate, targetStorage, Long.MAX_VALUE, false);
+            }
+
+            // All targets may be visited when energy is plentiful, so advancing by one rather than
+            // by the visit count ensures a different destination receives first chance next tick.
+            nextTargetIndex = (startIndex + 1) % targetCount;
+        }
     }
 }

--- a/common/src/main/java/rearth/oritech/block/entity/pipes/GenericPipeInterfaceEntity.java
+++ b/common/src/main/java/rearth/oritech/block/entity/pipes/GenericPipeInterfaceEntity.java
@@ -116,6 +116,7 @@ public abstract class GenericPipeInterfaceEntity extends BlockEntity implements 
 
         data.pipeNetworks.remove(oldNetwork);
         data.pipeNetworkInterfaces.remove(oldNetwork);
+        data.removeNetworkRevision(oldNetwork);
         data.pipeNetworkLinks.remove(pos);
 
         // re-calculate old network, is either shorter or split into multiple ones (starting from ones this block was connected to)
@@ -145,6 +146,7 @@ public abstract class GenericPipeInterfaceEntity extends BlockEntity implements 
         var netID = foundNetwork.hashCode();
         data.pipeNetworks.put(netID, foundNetwork);
         data.pipeNetworkInterfaces.put(netID, foundMachines);
+        data.markNetworkTopologyChanged(netID);
 
         // these networks will be replaced, since these nodes now belong to the new network
         var networksToRemove = new HashSet<Integer>();
@@ -157,6 +159,7 @@ public abstract class GenericPipeInterfaceEntity extends BlockEntity implements 
         networksToRemove.stream().filter(i -> i != -1 && i != netID).forEach(i -> {
             data.pipeNetworks.remove(i);
             data.pipeNetworkInterfaces.remove(i);
+            data.removeNetworkRevision(i);
         });
 
         data.setDirty();
@@ -287,6 +290,29 @@ public abstract class GenericPipeInterfaceEntity extends BlockEntity implements 
         public final HashMap<Integer, Set<Tuple<BlockPos, Direction>>> pipeNetworkInterfaces = new HashMap<>(); // list of machines that are connected to the network
 
         public final HashMap<BlockPos, Set<Direction>> machinePipeNeighbors = new HashMap<>(); // List of neighboring pipes per machine, and the direction they are in. Missing direction means no connection
+
+        // Runtime-only revisions used to invalidate dispatcher caches. Topology remains serialized
+        // in the collections above; these counters deliberately restart after a world reload.
+        private final HashMap<Integer, Long> networkRevisions = new HashMap<>();
+        private long topologyRevision;
+
+        public long getNetworkRevision(int networkId) {
+            return networkRevisions.getOrDefault(networkId, 0L);
+        }
+
+        public long getTopologyRevision() {
+            return topologyRevision;
+        }
+
+        private void markNetworkTopologyChanged(int networkId) {
+            networkRevisions.put(networkId, ++topologyRevision);
+        }
+
+        private void removeNetworkRevision(int networkId) {
+            if (networkRevisions.remove(networkId) != null) {
+                topologyRevision++;
+            }
+        }
 
         @Override
         public int hashCode() {


### PR DESCRIPTION
<!--- Thanks for opening a PR and contributing to Oritech. Before opening a PR, please fill out the following template: -->
# Description

Reworks energy pipe transfer to run once per network per tick with shared runtime state, rotating source/target fairness, and topology revision invalidation instead of per-interface target shuffling. Adds `AggregatingEnergyStorage` to extract across multiple interface buffers without buffering, prevents self-feedback loops, tracks network revision cleanup in `PipeNetworkData`, and clears runtime caches on server stop.

# How Has This Been Tested?

Tested on NeoForge & Fabric. Functions as intended. Significant performance improvements when many are connected like on a very large reactor output.

- [x] Feature has been tested ingame on both neoforge and fabric.
- [x] Optional additional testing details

# Checklist:

- [x] My code uses the 'var' keyword where applicable.
- [x] I have commented my code, particularly in hard-to-understand areas