### PR TITLE
Improve handling of custom fluids in tank renderers

### DIFF
--- a/common/src/main/java/rearth/oritech/client/renderers/RefineryRenderer.java
+++ b/common/src/main/java/rearth/oritech/client/renderers/RefineryRenderer.java
@@ -75,9 +75,8 @@ public class RefineryRenderer<T extends RefineryBlockEntity & GeoAnimatable> ext
     }
     
     private static void renderFluidCube(Vector3f min, Vector3f size, FluidStack drawnStack, Long tankCapacity, VertexConsumer consumer, PoseStack matrices, int light, int overlay, int index, VisualTankHeights lastHeight) {
-        var fluid = drawnStack.getFluid();
         var fill = drawnStack.getAmount() / (float) tankCapacity;
-        
+
         var lastFill = index == -1 ? lastHeight.input : lastHeight.outputs[index];
         var newFill = Mth.lerp(0.003f, lastFill, fill);
         if (index == -1) {
@@ -85,9 +84,9 @@ public class RefineryRenderer<T extends RefineryBlockEntity & GeoAnimatable> ext
         } else {
             lastHeight.outputs[index] = newFill;
         }
-        
-        var sprite = FluidStackHooks.getStillTexture(fluid);
-        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(fluid));
+
+        var sprite = FluidStackHooks.getStillTexture(drawnStack);
+        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(drawnStack));
         
         matrices.pushPose();
         matrices.translate(min.x + 0.01f, min.y + 0.01f, min.z + 0.01f);

--- a/common/src/main/java/rearth/oritech/client/renderers/SmallTankItemRenderer.java
+++ b/common/src/main/java/rearth/oritech/client/renderers/SmallTankItemRenderer.java
@@ -72,11 +72,10 @@ public class SmallTankItemRenderer {
             return;
         }
         
-        var fluid = storage.getFluid();
         var fill = storage.getAmount() / (float) (OritechConfig.portableTankCapacityBuckets.get() * FluidStackHooks.bucketAmount());
-        
-        var sprite = FluidStackHooks.getStillTexture(fluid);
-        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(fluid));
+
+        var sprite = FluidStackHooks.getStillTexture(storage);
+        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(storage));
         var consumer = vertexConsumers.getBuffer(RenderType.translucent());
         
         matrices.pushPose();

--- a/common/src/main/java/rearth/oritech/client/renderers/SmallTankRenderer.java
+++ b/common/src/main/java/rearth/oritech/client/renderers/SmallTankRenderer.java
@@ -21,11 +21,11 @@ public class SmallTankRenderer implements BlockEntityRenderer<SmallTankEntity> {
         var storage = entity.fluidStorage;
         if (storage.getAmount() <= 0 || storage.getFluid().equals(Fluids.EMPTY)) return;
         
-        var fluid = storage.getFluid();
+        var fluidStack = storage.getStack();
         var fill = storage.getAmount() / (float) storage.getCapacity();
-        
-        var sprite = FluidStackHooks.getStillTexture(fluid);
-        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(fluid));
+
+        var sprite = FluidStackHooks.getStillTexture(fluidStack);
+        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(fluidStack));
         var consumer = vertexConsumers.getBuffer(RenderType.translucent());
         
         matrices.pushPose();

--- a/common/src/main/java/rearth/oritech/client/renderers/TaintedRefineryRenderer.java
+++ b/common/src/main/java/rearth/oritech/client/renderers/TaintedRefineryRenderer.java
@@ -59,11 +59,10 @@ public class TaintedRefineryRenderer<T extends TaintedRefineryBlockEntity & GeoA
     }
     
     private static void renderFluidCube(Vector3f min, Vector3f size, FluidStack drawnStack, Long tankCapacity, VertexConsumer consumer, PoseStack matrices, int light, int overlay) {
-        var fluid = drawnStack.getFluid();
         var fill = drawnStack.getAmount() / (float) tankCapacity;
-        
-        var sprite = FluidStackHooks.getStillTexture(fluid);
-        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(fluid));
+
+        var sprite = FluidStackHooks.getStillTexture(drawnStack);
+        var spriteColor = ColorHelper.makeOpaque(FluidStackHooks.getColor(drawnStack));
         
         matrices.pushPose();
         matrices.translate(min.x + 0.01f, min.y + 0.01f, min.z + 0.01f);


### PR DESCRIPTION
# Description

This PR changes tank renderers to use `FluidStack` instead of `Fluid` in order to tint the fluid element. This is because it seems like some mods only override the `FluidStack` variant of `getTintColor` (most notably, Create: Dragons Plus and its liquid dyes). As far as I'm aware there's no downside to doing it this way, correct me if I'm wrong.

Before:
<img width="1935" height="679" alt="image showing previous rendering state, some tanks are white" src="https://github.com/user-attachments/assets/e8ef4890-d690-43d5-9b94-175718df5ff2" />

After:
<img width="1935" height="679" alt="image showing fixed rendering state, tanks which are previously white are now colored" src="https://github.com/user-attachments/assets/104f975d-a0b7-4ca5-95b0-470e564b82bb" />

Liquid dyes are no longer drawn as white.

# How Has This Been Tested?

- [X] Feature has been tested ingame on both neoforge and fabric.
- [X] Tested with Create: Dragons Plus fluids

# Checklist:

- [X] My code uses the 'var' keyword where applicable.
- [N/A] I have commented my code, particularly in hard-to-understand areas - N/A, I believe there's no need for extra comments.